### PR TITLE
ci: add PyPI publish workflow via Trusted Publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? If it closes an issue, write "Closes #123". -->

## Changes

<!-- A short bulleted list of the concrete changes. -->

-
-

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/`
- [x] Public-facing behavior changes are reflected in the README or `docs/`
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

<!-- How did you verify the change? e.g. unit tests added, tested live against a Claude Desktop session, etc. -->
