### PR TITLE
fix: resolve LICENSE link from PyPI (1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 [![Tests](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/hhopke/intervals-icu-mcp/blob/main/LICENSE)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/hhopke/intervals-icu-mcp/pkgs/container/intervals-icu-mcp)
 
 ## Overview
@@ -527,7 +527,7 @@ Issues and pull requests are welcome. Before opening a PR, run `make can-release
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details
+MIT License - see the [LICENSE](https://github.com/hhopke/intervals-icu-mcp/blob/main/LICENSE) file for details.
 
 ## Disclaimer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
 name = "intervals-icu-mcp"
-version = "1.0.1"
+version = "1.0.2"
 description = "Model Context Protocol server for Intervals.icu — access training data, wellness metrics, and performance analysis from Claude and other LLMs."
 readme = "README.md"
 license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [{ name = "Heiko Kromminga" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "intervals-icu-mcp"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Problem

Two things broke the LICENSE reference on the PyPI package page:

1. `[LICENSE](LICENSE)` — relative links in README.md resolve fine on GitHub but 404 on PyPI, which has no file system to walk.
2. No `license-files` entry in `pyproject.toml` — without it the wheel's `dist-info` contains no `licenses/LICENSE`, so PyPI's sidebar can't show the license text.

## Fix

- Changed both `(LICENSE)` occurrences to absolute `https://github.com/hhopke/intervals-icu-mcp/blob/main/LICENSE` URLs.
- Added `license-files = ["LICENSE"]` (PEP 639) to `pyproject.toml`. Verified the wheel now contains `intervals_icu_mcp-1.0.2.dist-info/licenses/LICENSE`.
- Version bump → **1.0.2**.

## After merging

Build and publish to PyPI:

```bash
uv build
uv publish
```

## Test plan

- [x] `make can-release` passes (59 tests, ruff, pyright)
- [x] `uv build` produces `dist/intervals_icu_mcp-1.0.2-py3-none-any.whl`
- [x] Wheel contains `dist-info/licenses/LICENSE`
- [x] After publishing: confirm PyPI page shows license text in sidebar and badge link opens GitHub LICENSE page