### PR TITLE
docs: trim README and extract reference content (#6)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Publish to PyPI
+name: Publish Release
 
 on:
   release:
     types: [published]
 
 jobs:
-  publish:
+  pypi:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -15,3 +15,33 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  mcp-registry:
+    needs: pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sync server.json version to release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo modelcontextprotocol/registry \
+            --pattern '*linux_amd64.tar.gz'
+          tar xzf mcp-publisher_*_linux_amd64.tar.gz
+          chmod +x mcp-publisher
+
+      - name: Publish to MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           --cov-fail-under=43
 
   package:
-    name: Validate package metadata and links
+    name: Validate package metadata and doc files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -62,11 +62,11 @@ jobs:
       - name: Validate PyPI metadata and README rendering
         run: make lint/package
 
-      - name: Check markdown links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
-        with:
-          args: >-
-            --include-fragments
-            --remap 'https://github.com/hhopke/intervals-icu-mcp/blob/main/(.*) ./$1'
-            README.md CHANGELOG.md docs/
-          fail: true
+      - name: Verify internal doc files exist
+        run: |
+          test -f CHANGELOG.md
+          test -f docs/tools.md
+          test -f docs/examples.md
+          test -f docs/architecture.md
+          test -f docs/testing.md
+          test -f .claude/skills/add-tool/SKILL.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: make lint/package
 
       - name: Check markdown links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
         with:
           args: --include-fragments README.md CHANGELOG.md docs/
           fail: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,24 @@ jobs:
           --cov=src/intervals_icu_mcp
           --cov-report=term-missing
           --cov-fail-under=43
+
+  package:
+    name: Validate package metadata and links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Validate PyPI metadata and README rendering
+        run: make lint/package
+
+      - name: Check markdown links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --include-fragments README.md CHANGELOG.md docs/
+          fail: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,8 @@ jobs:
       - name: Check markdown links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
         with:
-          args: --include-fragments README.md CHANGELOG.md docs/
+          args: >-
+            --include-fragments
+            --remap 'https://github.com/hhopke/intervals-icu-mcp/blob/main/(.*) ./$1'
+            README.md CHANGELOG.md docs/
           fail: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- HTTP and SSE transports via a `--transport` flag, enabling remote deployment behind a reverse proxy, tunnel, or container. See the Remote Deployment section of the README.
+- CI coverage gate to prevent regressions in test coverage.
+- Automated transport smoke test that replaces the previously manual MCP Inspector check.
+
+### Changed
+- Expanded the HTTP transport security warning in the README with concrete deployment guidance (Tailscale, Cloudflare Tunnel, reverse-proxy-with-auth, SSH tunnel).
+
+## [1.0.1] — 2026-04-24
+
+### Added
+- PyPI publish workflow via Trusted Publishers.
+- MCP Registry submission metadata (`server.json`).
+
+### Fixed
+- LICENSE file now packaged with the PyPI distribution and links resolve correctly from the PyPI page.
+- `server.json` description shortened to meet the MCP Registry 100-char limit.
+
+### Changed
+- Documentation leads with the `uvx` install flow now that the package is on PyPI.
+
+## [1.0.0] — 2026-04-23
+
+Initial release of this independent continuation of [eddmann/intervals-icu-mcp](https://github.com/eddmann/intervals-icu-mcp) (MIT).
+
+### Fixed
+- **Power/HR/pace curves** — rewrote curve models to match actual API response format, added required `type` parameter, fixed query parameter format.
+- **Fitness summary** — CTL/ATL/TSB now fetched from wellness endpoint (was returning empty from athlete endpoint).
+- **Duplicate events** — fixed to correct API endpoint and batch body format.
+- **Bulk delete events** — fixed HTTP method and endpoint.
+- **Activity intervals** — API returns wrapped `IntervalsDTO` object, not a flat list; fixed model to extract `icu_intervals`.
+- **Best efforts** — added required `stream` parameter (watts, heartrate, pace); fixed response model to match API `BestEfforts` format.
+- **Activity streams** — API returns array of stream objects, not a dict; fixed endpoint to use `.json` extension and correct model.
+- **Date parsing** — event tools now handle ISO-8601 datetime formats correctly.
+- **Missing event IDs** — calendar and workout responses include event IDs, enabling update/delete operations.
+
+### Added
+- **Structured Workout Generation** — LLM-ready workout syntax resource (`intervals-icu://workout-syntax`) and `generate_workout` prompt for creating valid structured workouts across cycling, running, and swimming. Syntax spec attributed to [MarvinNazari/intervals-icu-workout-parser](https://github.com/MarvinNazari/intervals-icu-workout-parser) (MIT).
+- **New Bulk/Streams APIs** — full support for `icu_apply_training_plan`, `icu_bulk_create_manual_activities`, and `icu_update_activity_streams`.
+- **MCP Builder Standards** — universal `icu_` naming prefix and `destructiveHint` safeguards for all modification tools.
+- **Multi-athlete support** — optional `athlete_id` parameter on activity, event, and calendar tools.
+- **MCP verification prompts** — `verify-setup` and `verify-multi-athlete` for live validation.
+
+### Changed
+- Upgraded to FastMCP 3.x.
+- Added middleware integration tests.
+- Added tests for multi-athlete routing, model aliases, and date handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.1] — 2026-04-24
+
+### Added
+- Automated MCP Registry publishing on release via GitHub OIDC — `server.json` version is synced from the release tag, no manual bump required.
+
+### Changed
+- README trimmed; reference content extracted to [docs/examples.md](docs/examples.md) and [docs/tools.md](docs/tools.md) for clearer onboarding and discoverability.
+
+## [1.1.0] — 2026-04-24
 
 ### Added
 - HTTP and SSE transports via a `--transport` flag, enabling remote deployment behind a reverse proxy, tunnel, or container. See the Remote Deployment section of the README.

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ lint/pyright: ## Run pyright type checker
 lint/package: ## Validate PyPI package metadata and README rendering (twine + pyroma)
 	rm -rf dist/
 	uv build
-	uvx twine check --strict dist/*
-	uvx pyroma --min=10 .
+	uvx twine==6.2.0 check --strict dist/*
+	uvx pyroma==5.0.1 --min=10 .
 
 lint/links: ## Check markdown links (requires lychee: `brew install lychee`)
 	@command -v lychee >/dev/null 2>&1 || { echo "lychee not installed. Install with: brew install lychee"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ lint/package: ## Validate PyPI package metadata and README rendering (twine + py
 
 lint/links: ## Check markdown links (requires lychee: `brew install lychee`)
 	@command -v lychee >/dev/null 2>&1 || { echo "lychee not installed. Install with: brew install lychee"; exit 1; }
-	lychee --include-fragments README.md CHANGELOG.md docs/
+	lychee --include-fragments \
+		--remap 'https://github.com/hhopke/intervals-icu-mcp/blob/main/(.*) ./$1' \
+		README.md CHANGELOG.md docs/
 
 fmt: format
 format: ## Fix style violations and format code

--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,6 @@ lint/package: ## Validate PyPI package metadata and README rendering (twine + py
 	uvx twine==6.2.0 check --strict dist/*
 	uvx pyroma==5.0.1 --min=10 .
 
-lint/links: ## Check markdown links (requires lychee: `brew install lychee`)
-	@command -v lychee >/dev/null 2>&1 || { echo "lychee not installed. Install with: brew install lychee"; exit 1; }
-	lychee --include-fragments \
-		--remap 'https://github.com/hhopke/intervals-icu-mcp/blob/main/(.*) ./$1' \
-		README.md CHANGELOG.md docs/
-
 fmt: format
 format: ## Fix style violations and format code
 	uv run ruff check --fix

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean: ## Clean up cache files and build artifacts
 
 ##@ Testing/Linting
 
-can-release: test lint ## Run all the same checks as CI to ensure code can be released
+can-release: test lint lint/package ## Run all the same checks as CI to ensure code can be released
 
 test: ## Run the test suite
 	uv run pytest
@@ -50,6 +50,16 @@ lint/ruff: ## Run ruff linter
 
 lint/pyright: ## Run pyright type checker
 	uv run pyright
+
+lint/package: ## Validate PyPI package metadata and README rendering (twine + pyroma)
+	rm -rf dist/
+	uv build
+	uvx twine check --strict dist/*
+	uvx pyroma --min=10 .
+
+lint/links: ## Check markdown links (requires lychee: `brew install lychee`)
+	@command -v lychee >/dev/null 2>&1 || { echo "lychee not installed. Install with: brew install lychee"; exit 1; }
+	lychee --include-fragments README.md CHANGELOG.md docs/
 
 fmt: format
 format: ## Fix style violations and format code

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Intervals.icu MCP Server
 
-![intervals-icu-mcp demo](/docs/demo.gif)
+![intervals-icu-mcp demo](https://raw.githubusercontent.com/hhopke/intervals-icu-mcp/main/docs/demo.gif)
 
 A Model Context Protocol (MCP) server for Intervals.icu integration. Access your training data, wellness metrics, and performance analysis through Claude and other LLMs.
 
-> Originally based on [eddmann/intervals-icu-mcp](https://github.com/eddmann/intervals-icu-mcp) (MIT licensed). This project is an independent continuation with significant bug fixes and new features — see [Changelog](#changelog) for details.
+> Originally based on [eddmann/intervals-icu-mcp](https://github.com/eddmann/intervals-icu-mcp) (MIT licensed). This project is an independent continuation with significant bug fixes and new features — see [CHANGELOG.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/CHANGELOG.md) for details.
 
 [![Tests](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
@@ -15,22 +15,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-This MCP server provides 51 tools to interact with your Intervals.icu account, organized into 9 categories:
-
-- Activities (12 tools) - Query, search, update, delete, and download activities
-- Activity Analysis (8 tools) - Deep dive into streams, intervals, best efforts, and histograms
-- Athlete (2 tools) - Access profile, fitness metrics, and training load
-- Wellness (3 tools) - Track and update recovery, HRV, sleep, and health metrics
-- Events/Calendar (10 tools) - Manage planned workouts, races, notes with bulk operations
-- Performance/Curves (3 tools) - Analyze power, heart rate, and pace curves
-- Workout Library (2 tools) - Browse and explore workout templates and plans
-- Gear Management (6 tools) - Track equipment and maintenance reminders
-- Sport Settings (5 tools) - Configure FTP, FTHR, pace thresholds, and zones
-
-Additionally, the server provides:
-
-- 2 MCP Resources - Athlete profile with fitness metrics, and structured workout syntax reference for LLM-guided workout generation
-- 7 MCP Prompts - Templates for common queries (training analysis, performance analysis, activity deep dive, recovery check, training plan review, weekly planning, workout generation)
+51 tools spanning activities, activity analysis, athlete profile, wellness, events/calendar, performance curves, workout library, gear, and sport settings — plus 2 MCP Resources (athlete profile, workout syntax reference) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
 
 ## Quick Start
 
@@ -60,106 +45,59 @@ Prefer Claude Code or Cursor? See [Client Configuration](#client-configuration).
 
 ## Prerequisites
 
-Install [uv](https://github.com/astral-sh/uv) — it handles Python, dependencies, and execution in one tool:
-
-```bash
-# macOS / Linux
-brew install uv
-# or: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-That's all you need — `uvx` will fetch Python and the package automatically. Docker is also supported as an alternative.
+Install [uv](https://github.com/astral-sh/uv) — it handles Python, dependencies, and execution in one tool. `brew install uv` on macOS/Linux, or `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` on Windows. From there, `uvx` fetches Python and the package automatically. Docker is also supported as an alternative.
 
 ## Intervals.icu API Key Setup
 
-Before installation, you need to obtain your Intervals.icu API key:
+Before installation, obtain your Intervals.icu API key:
 
-1. Go to https://intervals.icu/settings
-2. Scroll to the **Developer** section
-3. Click **Create API Key**
-4. Copy the API key (you'll use it during setup)
-5. Note your **Athlete ID** from your profile URL (format: `i123456`)
+1. Go to https://intervals.icu/settings → **Developer** → **Create API Key**.
+2. Copy the key, and note your **Athlete ID** from your profile URL (format: `i123456`).
 
 ## Installation & Setup
 
-### How Authentication Works
+Credentials are passed via the `env` block in your MCP client config (see [Client Configuration](#client-configuration)) or, for source installs, via a local `.env` file.
 
-1. API Key - Simple API key authentication (no OAuth required)
-2. Configuration - API key and athlete ID provided via environment variables (or `.env` file when running from source)
-3. Basic Auth - HTTP Basic Auth with username "API_KEY" and your key as password
-4. Persistence - Subsequent runs reuse stored credentials
+### Using uvx (recommended)
 
-### Option 1: Using uvx (Recommended)
-
-No clone, no manual install. Credentials are passed via the `env` block in your MCP client config (see [Client Configuration](#client-configuration)).
+No clone, no manual install — `uvx` downloads the package from PyPI on first run, caches it, and reuses the cache thereafter.
 
 ```bash
 # Optional: test it runs locally
 INTERVALS_ICU_API_KEY=your_key INTERVALS_ICU_ATHLETE_ID=i123456 uvx intervals-icu-mcp
 ```
 
-`uvx` downloads the package from PyPI on first run, caches it, and reuses the cache thereafter.
-
-### Option 2: From Source
-
-For development or if you want to modify the server:
+<details>
+<summary><b>From source</b> — for development or local modifications</summary>
 
 ```bash
 git clone https://github.com/hhopke/intervals-icu-mcp.git
 cd intervals-icu-mcp
 uv sync
+uv run intervals-icu-mcp-auth  # interactive credential setup; or create .env manually:
+#   INTERVALS_ICU_API_KEY=your_api_key_here
+#   INTERVALS_ICU_ATHLETE_ID=i123456
 ```
 
-Then configure credentials using one of these methods:
+</details>
 
-#### Interactive Setup
-
-```bash
-uv run intervals-icu-mcp-auth
-```
-
-This will prompt for your API key and athlete ID and save credentials to `.env`.
-
-#### Manual Setup
-
-Create a `.env` file manually:
+<details>
+<summary><b>Using Docker</b></summary>
 
 ```bash
-INTERVALS_ICU_API_KEY=your_api_key_here
-INTERVALS_ICU_ATHLETE_ID=i123456
-```
-
-### Option 3: Using Docker
-
-```bash
-# Build the image
 docker build -t intervals-icu-mcp .
-```
 
-Then configure credentials using one of these methods:
-
-#### Interactive Setup
-
-```bash
-# Create the env file first (Docker will create it as a directory if it doesn't exist)
-touch intervals-icu-mcp.env
-
-# Run the setup script
+# Interactive credential setup (creates intervals-icu-mcp.env in the current directory):
+touch intervals-icu-mcp.env  # pre-create the file so Docker mounts it as a file, not a dir
 docker run -it --rm \
-  -v "/ABSOLUTE/PATH/TO/intervals-icu-mcp.env:/app/.env" \
-  --entrypoint= \
-  intervals-icu-mcp:latest \
+  -v "$(pwd)/intervals-icu-mcp.env:/app/.env" \
+  --entrypoint= intervals-icu-mcp:latest \
   python -m intervals_icu_mcp.scripts.setup_auth
 ```
 
-This will prompt for credentials and save them to `intervals-icu-mcp.env`.
+Or create `intervals-icu-mcp.env` manually (same format as the `.env` above).
 
-#### Manual Setup
-
-Create an `intervals-icu-mcp.env` file manually in your current directory (see UV manual setup above for format).
+</details>
 
 ## Client Configuration
 
@@ -171,8 +109,6 @@ Add to your configuration file:
 
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-#### Using uvx (recommended)
 
 ```json
 {
@@ -189,9 +125,10 @@ Add to your configuration file:
 }
 ```
 
-#### From source
+<details>
+<summary>Alternate flavors: from source / Docker</summary>
 
-Requires having cloned the repo and run `uv sync` + `uv run intervals-icu-mcp-auth`.
+**From source** (requires `git clone` + `uv sync` + `uv run intervals-icu-mcp-auth`):
 
 ```json
 {
@@ -209,7 +146,7 @@ Requires having cloned the repo and run `uv sync` + `uv run intervals-icu-mcp-au
 }
 ```
 
-#### Using Docker
+**Docker**:
 
 ```json
 {
@@ -228,6 +165,8 @@ Requires having cloned the repo and run `uv sync` + `uv run intervals-icu-mcp-au
   }
 }
 ```
+
+</details>
 
 ### Claude Code
 
@@ -297,265 +236,46 @@ All flags:
 
 ## Usage
 
-Ask Claude to interact with your Intervals.icu data using natural language. The server provides tools, a resource, and prompt templates to help you get started.
-
-### Try the MCP Prompts
-
-Use built-in prompt templates for common queries (available via prompt suggestions in Claude):
-
-- `analyze-recent-training` - Comprehensive training analysis over a specified period
-- `performance-analysis` - Analyze power/HR/pace curves and zones
-- `activity-deep-dive` - Deep dive into a specific activity with streams, intervals, and best efforts
-- `recovery-check` - Recovery assessment with wellness trends and training load
-- `training-plan-review` - Weekly training plan evaluation with workout library
-- `plan-training-week` - AI-assisted weekly training plan creation based on current fitness
-- `generate-workout` - Generate a structured workout for any sport (cycling, running, swimming) with proper Intervals.icu syntax
-
-### Activities
+Ask Claude to interact with your Intervals.icu data in natural language. A few starter prompts:
 
 ```
 "Show me my activities from the last 30 days"
-"Get details for my last long run"
-"Find all my threshold workouts"
-"Update the name of my last activity"
-"Delete that duplicate activity"
-"Download the FIT file for my race"
-```
-
-### Activity Analysis
-
-```
-"Show me the power data from yesterday's ride"
-"What were my best efforts in my last race?"
-"Find similar interval workouts to my last session"
-"Show me the intervals from my workout on Tuesday"
-"Get the power histogram for my last ride"
-"Show me the heart rate distribution for that workout"
-```
-
-### Athlete Profile & Fitness
-
-```
-"Show my current fitness metrics and training load"
 "Am I overtraining? Check my CTL, ATL, and TSB"
-```
-
-_Note: The athlete profile resource (`intervals-icu://athlete/profile`) automatically provides ongoing context._
-
-### Wellness & Recovery
-
-```
 "How's my recovery this week? Show HRV and sleep trends"
-"What was my wellness data for yesterday?"
-"Update my wellness data for today - I slept 8 hours and feel great"
-```
-
-### Calendar & Planning
-
-```
-"What workouts do I have planned this week?"
 "Create a sweet spot cycling workout for tomorrow"
-"Create a tempo run with 800m repeats for Wednesday"
-"Generate a CSS swim training session for Friday"
-"Update my workout on Friday"
-"Delete the workout on Saturday"
-"Duplicate this week's plan for next week"
-"Create 5 workouts for my build phase"
-```
-
-> **Structured Workouts**: The server includes a complete workout syntax reference (`intervals-icu://workout-syntax`) that enables LLMs to generate valid structured workouts with proper power/HR/pace targets, zones, ramps, repeats, and cadence for cycling, running, and swimming.
-
-### Performance Analysis
-
-```
 "What's my 20-minute power and FTP?"
-"Show me my heart rate zones"
-"Analyze my running pace curve"
 ```
 
-### Workout Library
-
-```
-"Show me my workout library"
-"What workouts are in my threshold folder?"
-```
-
-### Gear Management
-
-```
-"Show me my gear list"
-"Add my new running shoes to gear tracking"
-"Create a reminder to replace my bike chain at 3000km"
-"Update the mileage on my road bike"
-```
-
-### Sport Settings
-
-```
-"Update my FTP to 275 watts"
-"Show my current zone settings for cycling"
-"Set my running threshold pace to 4:30 per kilometer"
-"Apply my new threshold settings to historical activities"
-```
+For the full catalogue of example prompts by category, see [docs/examples.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/examples.md).
 
 ## Available Tools
 
-### Activities (12 tools)
+51 tools, 2 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
 
-| Tool                     | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `icu_get_recent_activities`  | List recent activities with summary metrics       |
-| `icu_get_activity_details`   | Get comprehensive details for a specific activity |
-| `icu_search_activities`      | Search activities by name or tag                  |
-| `icu_search_activities_full` | Search activities with full details               |
-| `icu_get_activities_around`  | Get activities before and after a specific one    |
-| `icu_update_activity`        | Update activity name, description, or metadata    |
-| `icu_delete_activity`        | Delete an activity                                |
-| `icu_download_activity_file` | Download original activity file                   |
-| `icu_download_fit_file`      | Download activity as FIT file                     |
-| `icu_download_gpx_file`      | Download activity as GPX file                     |
-| `icu_bulk_create_manual_activities` | Create multiple manual activities with upsert on external_id |
-| `icu_update_activity_streams` | Update raw timeseries streams for an activity (JSON or CSV) |
-
-### Activity Analysis (8 tools)
-
-| Tool                     | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- |
-| `icu_get_activity_streams`   | Get time-series data (power, HR, cadence, altitude, GPS)      |
-| `icu_get_activity_intervals` | Get structured workout intervals with targets and performance |
-| `icu_get_best_efforts`       | Find peak performances across all durations in an activity    |
-| `icu_search_intervals`       | Find similar intervals across activity history                |
-| `icu_get_power_histogram`    | Get power distribution histogram for an activity              |
-| `icu_get_hr_histogram`       | Get heart rate distribution histogram for an activity         |
-| `icu_get_pace_histogram`     | Get pace distribution histogram for an activity               |
-| `icu_get_gap_histogram`      | Get grade-adjusted pace histogram for an activity             |
-
-### Athlete (2 tools)
-
-| Tool                  | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `icu_get_athlete_profile` | Get athlete profile with fitness metrics and sport settings     |
-| `icu_get_fitness_summary` | Get detailed CTL/ATL/TSB analysis with training recommendations |
-
-### Wellness (3 tools)
-
-| Tool                    | Description                                                         |
-| ----------------------- | ------------------------------------------------------------------- |
-| `icu_get_wellness_data`     | Get recent wellness metrics with trends (HRV, sleep, mood, fatigue) |
-| `icu_get_wellness_for_date` | Get complete wellness data for a specific date                      |
-| `icu_update_wellness`       | Update or create wellness data for a date                           |
-
-### Events/Calendar (10 tools)
-
-| Tool                    | Description                                                |
-| ----------------------- | ---------------------------------------------------------- |
-| `icu_get_calendar_events`   | Get planned events and workouts from calendar              |
-| `icu_get_upcoming_workouts` | Get upcoming planned workouts only                         |
-| `icu_get_event`             | Get details for a specific event                           |
-| `icu_create_event`          | Create new calendar events (workouts, races, notes, goals) |
-| `icu_update_event`          | Modify existing calendar events                            |
-| `icu_delete_event`          | Remove events from calendar                                |
-| `icu_bulk_create_events`    | Create multiple events in a single operation               |
-| `icu_bulk_delete_events`    | Delete multiple events in a single operation               |
-| `icu_duplicate_events`      | Duplicate one or more events with configurable copies and spacing |
-| `icu_apply_training_plan` | Apply an entire training plan (workout folder) onto the calendar |
-
-### Performance/Curves (3 tools)
-
-| Tool               | Description                                              |
-| ------------------ | -------------------------------------------------------- |
-| `icu_get_power_curves` | Analyze power curves with FTP estimation and power zones |
-| `icu_get_hr_curves`    | Analyze heart rate curves with HR zones                  |
-| `icu_get_pace_curves`  | Analyze running/swimming pace curves with optional GAP   |
-
-### Workout Library (2 tools)
-
-| Tool                     | Description                               |
-| ------------------------ | ----------------------------------------- |
-| `icu_get_workout_library`    | Browse workout folders and training plans |
-| `icu_get_workouts_in_folder` | View all workouts in a specific folder    |
-
-### Gear Management (6 tools)
-
-| Tool                   | Description                                |
-| ---------------------- | ------------------------------------------ |
-| `icu_get_gear_list`        | Get all gear items with usage and status   |
-| `icu_create_gear`          | Add new gear to tracking                   |
-| `icu_update_gear`          | Update gear details, mileage, or status    |
-| `icu_delete_gear`          | Remove gear from tracking                  |
-| `icu_create_gear_reminder` | Create maintenance reminders for gear      |
-| `icu_update_gear_reminder` | Update existing gear maintenance reminders |
-
-### Sport Settings (5 tools)
-
-| Tool                    | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `icu_get_sport_settings`    | Get sport-specific settings and thresholds              |
-| `icu_update_sport_settings` | Update FTP, FTHR, pace threshold, or zone configuration |
-| `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
-| `icu_create_sport_settings` | Create new sport-specific settings                      |
-| `icu_delete_sport_settings` | Delete sport-specific settings                          |
-
-## MCP Resources
-
-Resources provide ongoing context to the LLM without requiring explicit tool calls:
-
-| Resource                          | Description                                                              |
-| --------------------------------- | ------------------------------------------------------------------------ |
-| `intervals-icu://athlete/profile` | Complete athlete profile with current fitness metrics and sport settings |
-| `intervals-icu://workout-syntax`  | Structured workout syntax reference for generating valid Intervals.icu workouts (cycling, running, swimming) |
-
-## MCP Prompts
-
-Prompt templates for common queries (accessible via prompt suggestions in Claude):
-
-| Prompt                    | Description                                                              |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `icu_analyze_recent_training` | Comprehensive training analysis over a specified period                  |
-| `icu_performance_analysis`    | Detailed power/HR/pace curve analysis with zones                         |
-| `icu_activity_deep_dive`      | Deep dive into a specific activity with streams, intervals, best efforts |
-| `icu_recovery_check`          | Recovery assessment with wellness trends and training load               |
-| `icu_training_plan_review`    | Weekly training plan evaluation with workout library                     |
-| `icu_plan_training_week`      | AI-assisted weekly training plan creation based on current fitness       |
-| `generate_workout`            | Generate a structured workout with sport, type, and duration parameters  |
-
-## Changelog
-
-### Bug fixes
-
-- **Power/HR/pace curves** — rewrote curve models to match actual API response format, added required `type` parameter, fixed query parameter format
-- **Fitness summary** — CTL/ATL/TSB now fetched from wellness endpoint (was returning empty from athlete endpoint)
-- **Duplicate events** — fixed to correct API endpoint and batch body format
-- **Bulk delete events** — fixed HTTP method and endpoint
-- **Activity intervals** — API returns wrapped `IntervalsDTO` object, not a flat list; fixed model to extract `icu_intervals`
-- **Best efforts** — added required `stream` parameter (watts, heartrate, pace); fixed response model to match API `BestEfforts` format
-- **Activity streams** — API returns array of stream objects, not a dict; fixed endpoint to use `.json` extension and correct model
-- **Date parsing** — event tools now handle ISO-8601 datetime formats correctly
-- **Missing event IDs** — calendar and workout responses include event IDs, enabling update/delete operations
-
-### New features
-
-- **Structured Workout Generation** — LLM-ready workout syntax resource (`intervals-icu://workout-syntax`) and `generate_workout` prompt for creating valid structured workouts across cycling, running, and swimming. Syntax spec attributed to [MarvinNazari/intervals-icu-workout-parser](https://github.com/MarvinNazari/intervals-icu-workout-parser) (MIT)
-- **New Bulk/Streams APIs** — full support for `icu_apply_training_plan`, `icu_bulk_create_manual_activities` and `icu_update_activity_streams`
-- **MCP Builder Standards** — implemented universal `icu_` naming prefix and `destructiveHint` safeguards for all modification tools
-- **Multi-athlete support** — optional `athlete_id` parameter on activity, event, and calendar tools
-- **MCP verification prompts** — `verify-setup` and `verify-multi-athlete` for live validation
-
-### Infrastructure
-
-- Upgraded to FastMCP 3.x
-- Added middleware integration tests
-- Added tests for multi-athlete routing, model aliases, and date handling
+| Category | Tools | Summary |
+|---|---|---|
+| [Activities](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activities-12-tools) | 12 | Query, search, update, delete, download activities |
+| [Activity Analysis](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activity-analysis-8-tools) | 8 | Streams, intervals, best efforts, histograms |
+| [Athlete](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#athlete-2-tools) | 2 | Profile and CTL/ATL/TSB fitness analysis |
+| [Wellness](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#wellness-3-tools) | 3 | HRV, sleep, recovery metrics |
+| [Events / Calendar](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#events--calendar-10-tools) | 10 | Planned workouts, races, notes (bulk ops supported) |
+| [Performance / Curves](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#performance--curves-3-tools) | 3 | Power, HR, and pace curves with zones |
+| [Workout Library](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#workout-library-2-tools) | 2 | Browse workout folders and training plans |
+| [Gear Management](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#gear-management-6-tools) | 6 | Track equipment and maintenance reminders |
+| [Sport Settings](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#sport-settings-5-tools) | 5 | FTP, FTHR, pace thresholds, and zones |
 
 ## Documentation
 
-- [Architecture overview](docs/architecture.md) — how the server, middleware, client, and tools fit together
-- [Testing guide](docs/testing.md) — conventions for pytest + respx, fixtures, and running the suite
-- [Adding a new tool](.claude/skills/add-tool/SKILL.md) — step-by-step workflow for contributors
+- [Example prompts](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/examples.md) — full catalogue of natural-language prompts by category
+- [Tool reference](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md) — complete tool, resource, and prompt inventory
+- [Architecture overview](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/architecture.md) — how the server, middleware, client, and tools fit together
+- [Testing guide](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/testing.md) — conventions for pytest + respx, fixtures, and running the suite
+- [Changelog](https://github.com/hhopke/intervals-icu-mcp/blob/main/CHANGELOG.md) — release history
+- [Adding a new tool](https://github.com/hhopke/intervals-icu-mcp/blob/main/.claude/skills/add-tool/SKILL.md) — step-by-step workflow for contributors
 
 ## Contributing
 
-Issues and pull requests are welcome. Before opening a PR, run `make can-release` locally to match what CI enforces (ruff, pyright, pytest). For new tools, follow the pattern in [`.claude/skills/add-tool/SKILL.md`](.claude/skills/add-tool/SKILL.md) and add a respx-mocked test file alongside the implementation.
+Issues and pull requests are welcome. Before opening a PR, run `make can-release` locally to match what CI enforces (ruff, pyright, pytest). For new tools, follow the pattern in [`.claude/skills/add-tool/SKILL.md`](https://github.com/hhopke/intervals-icu-mcp/blob/main/.claude/skills/add-tool/SKILL.md) and add a respx-mocked test file alongside the implementation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 - [Tool reference](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md) — complete tool, resource, and prompt inventory
 - [Architecture overview](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/architecture.md) — how the server, middleware, client, and tools fit together
 - [Testing guide](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/testing.md) — conventions for pytest + respx, fixtures, and running the suite
-- [Changelog](https://github.com/hhopke/intervals-icu-mcp/blob/main/CHANGELOG.md) — release history
+- [Changelog](CHANGELOG.md) — release history
 - [Adding a new tool](https://github.com/hhopke/intervals-icu-mcp/blob/main/.claude/skills/add-tool/SKILL.md) — step-by-step workflow for contributors
 
 ## Contributing

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,102 @@
+# Usage Examples
+
+Ask Claude to interact with your Intervals.icu data using natural language. This page collects example prompts organized by tool category. For the full tool reference, see [tools.md](tools.md).
+
+## MCP Prompts
+
+Built-in prompt templates for common queries, available via prompt suggestions in Claude:
+
+- `analyze-recent-training` — comprehensive training analysis over a specified period
+- `performance-analysis` — analyze power/HR/pace curves and zones
+- `activity-deep-dive` — deep dive into a specific activity with streams, intervals, and best efforts
+- `recovery-check` — recovery assessment with wellness trends and training load
+- `training-plan-review` — weekly training plan evaluation with workout library
+- `plan-training-week` — AI-assisted weekly training plan creation based on current fitness
+- `generate-workout` — generate a structured workout for any sport (cycling, running, swimming) with proper Intervals.icu syntax
+
+## Activities
+
+```
+"Show me my activities from the last 30 days"
+"Get details for my last long run"
+"Find all my threshold workouts"
+"Update the name of my last activity"
+"Delete that duplicate activity"
+"Download the FIT file for my race"
+```
+
+## Activity Analysis
+
+```
+"Show me the power data from yesterday's ride"
+"What were my best efforts in my last race?"
+"Find similar interval workouts to my last session"
+"Show me the intervals from my workout on Tuesday"
+"Get the power histogram for my last ride"
+"Show me the heart rate distribution for that workout"
+```
+
+## Athlete Profile & Fitness
+
+```
+"Show my current fitness metrics and training load"
+"Am I overtraining? Check my CTL, ATL, and TSB"
+```
+
+_Note: The athlete profile resource (`intervals-icu://athlete/profile`) automatically provides ongoing context._
+
+## Wellness & Recovery
+
+```
+"How's my recovery this week? Show HRV and sleep trends"
+"What was my wellness data for yesterday?"
+"Update my wellness data for today - I slept 8 hours and feel great"
+```
+
+## Calendar & Planning
+
+```
+"What workouts do I have planned this week?"
+"Create a sweet spot cycling workout for tomorrow"
+"Create a tempo run with 800m repeats for Wednesday"
+"Generate a CSS swim training session for Friday"
+"Update my workout on Friday"
+"Delete the workout on Saturday"
+"Duplicate this week's plan for next week"
+"Create 5 workouts for my build phase"
+```
+
+> **Structured Workouts**: The server includes a complete workout syntax reference (`intervals-icu://workout-syntax`) that enables LLMs to generate valid structured workouts with proper power/HR/pace targets, zones, ramps, repeats, and cadence for cycling, running, and swimming.
+
+## Performance Analysis
+
+```
+"What's my 20-minute power and FTP?"
+"Show me my heart rate zones"
+"Analyze my running pace curve"
+```
+
+## Workout Library
+
+```
+"Show me my workout library"
+"What workouts are in my threshold folder?"
+```
+
+## Gear Management
+
+```
+"Show me my gear list"
+"Add my new running shoes to gear tracking"
+"Create a reminder to replace my bike chain at 3000km"
+"Update the mileage on my road bike"
+```
+
+## Sport Settings
+
+```
+"Update my FTP to 275 watts"
+"Show my current zone settings for cycling"
+"Set my running threshold pace to 4:30 per kilometer"
+"Apply my new threshold settings to historical activities"
+```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,124 @@
+# Tool, Resource, and Prompt Reference
+
+Complete inventory of everything the Intervals.icu MCP server exposes: 51 tools across 9 categories, 2 MCP Resources, and 7 MCP Prompts.
+
+## Tools
+
+### Activities (12 tools)
+
+| Tool                     | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `icu_get_recent_activities`  | List recent activities with summary metrics       |
+| `icu_get_activity_details`   | Get comprehensive details for a specific activity |
+| `icu_search_activities`      | Search activities by name or tag                  |
+| `icu_search_activities_full` | Search activities with full details               |
+| `icu_get_activities_around`  | Get activities before and after a specific one    |
+| `icu_update_activity`        | Update activity name, description, or metadata    |
+| `icu_delete_activity`        | Delete an activity                                |
+| `icu_download_activity_file` | Download original activity file                   |
+| `icu_download_fit_file`      | Download activity as FIT file                     |
+| `icu_download_gpx_file`      | Download activity as GPX file                     |
+| `icu_bulk_create_manual_activities` | Create multiple manual activities with upsert on external_id |
+| `icu_update_activity_streams` | Update raw timeseries streams for an activity (JSON or CSV) |
+
+### Activity Analysis (8 tools)
+
+| Tool                     | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| `icu_get_activity_streams`   | Get time-series data (power, HR, cadence, altitude, GPS)      |
+| `icu_get_activity_intervals` | Get structured workout intervals with targets and performance |
+| `icu_get_best_efforts`       | Find peak performances across all durations in an activity    |
+| `icu_search_intervals`       | Find similar intervals across activity history                |
+| `icu_get_power_histogram`    | Get power distribution histogram for an activity              |
+| `icu_get_hr_histogram`       | Get heart rate distribution histogram for an activity         |
+| `icu_get_pace_histogram`     | Get pace distribution histogram for an activity               |
+| `icu_get_gap_histogram`      | Get grade-adjusted pace histogram for an activity             |
+
+### Athlete (2 tools)
+
+| Tool                  | Description                                                     |
+| --------------------- | --------------------------------------------------------------- |
+| `icu_get_athlete_profile` | Get athlete profile with fitness metrics and sport settings     |
+| `icu_get_fitness_summary` | Get detailed CTL/ATL/TSB analysis with training recommendations |
+
+### Wellness (3 tools)
+
+| Tool                    | Description                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| `icu_get_wellness_data`     | Get recent wellness metrics with trends (HRV, sleep, mood, fatigue) |
+| `icu_get_wellness_for_date` | Get complete wellness data for a specific date                      |
+| `icu_update_wellness`       | Update or create wellness data for a date                           |
+
+### Events / Calendar (10 tools)
+
+| Tool                    | Description                                                |
+| ----------------------- | ---------------------------------------------------------- |
+| `icu_get_calendar_events`   | Get planned events and workouts from calendar              |
+| `icu_get_upcoming_workouts` | Get upcoming planned workouts only                         |
+| `icu_get_event`             | Get details for a specific event                           |
+| `icu_create_event`          | Create new calendar events (workouts, races, notes, goals) |
+| `icu_update_event`          | Modify existing calendar events                            |
+| `icu_delete_event`          | Remove events from calendar                                |
+| `icu_bulk_create_events`    | Create multiple events in a single operation               |
+| `icu_bulk_delete_events`    | Delete multiple events in a single operation               |
+| `icu_duplicate_events`      | Duplicate one or more events with configurable copies and spacing |
+| `icu_apply_training_plan` | Apply an entire training plan (workout folder) onto the calendar |
+
+### Performance / Curves (3 tools)
+
+| Tool               | Description                                              |
+| ------------------ | -------------------------------------------------------- |
+| `icu_get_power_curves` | Analyze power curves with FTP estimation and power zones |
+| `icu_get_hr_curves`    | Analyze heart rate curves with HR zones                  |
+| `icu_get_pace_curves`  | Analyze running/swimming pace curves with optional GAP   |
+
+### Workout Library (2 tools)
+
+| Tool                     | Description                               |
+| ------------------------ | ----------------------------------------- |
+| `icu_get_workout_library`    | Browse workout folders and training plans |
+| `icu_get_workouts_in_folder` | View all workouts in a specific folder    |
+
+### Gear Management (6 tools)
+
+| Tool                   | Description                                |
+| ---------------------- | ------------------------------------------ |
+| `icu_get_gear_list`        | Get all gear items with usage and status   |
+| `icu_create_gear`          | Add new gear to tracking                   |
+| `icu_update_gear`          | Update gear details, mileage, or status    |
+| `icu_delete_gear`          | Remove gear from tracking                  |
+| `icu_create_gear_reminder` | Create maintenance reminders for gear      |
+| `icu_update_gear_reminder` | Update existing gear maintenance reminders |
+
+### Sport Settings (5 tools)
+
+| Tool                    | Description                                             |
+| ----------------------- | ------------------------------------------------------- |
+| `icu_get_sport_settings`    | Get sport-specific settings and thresholds              |
+| `icu_update_sport_settings` | Update FTP, FTHR, pace threshold, or zone configuration |
+| `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
+| `icu_create_sport_settings` | Create new sport-specific settings                      |
+| `icu_delete_sport_settings` | Delete sport-specific settings                          |
+
+## MCP Resources
+
+Resources provide ongoing context to the LLM without requiring explicit tool calls.
+
+| Resource                          | Description                                                              |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| `intervals-icu://athlete/profile` | Complete athlete profile with current fitness metrics and sport settings |
+| `intervals-icu://workout-syntax`  | Structured workout syntax reference for generating valid Intervals.icu workouts (cycling, running, swimming) |
+
+## MCP Prompts
+
+Prompt templates for common queries, accessible via prompt suggestions in Claude.
+
+| Prompt                    | Description                                                              |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `icu_analyze_recent_training` | Comprehensive training analysis over a specified period                  |
+| `icu_performance_analysis`    | Detailed power/HR/pace curve analysis with zones                         |
+| `icu_activity_deep_dive`      | Deep dive into a specific activity with streams, intervals, best efforts |
+| `icu_recovery_check`          | Recovery assessment with wellness trends and training load               |
+| `icu_training_plan_review`    | Weekly training plan evaluation with workout library                     |
+| `icu_plan_training_week`      | AI-assisted weekly training plan creation based on current fitness       |
+| `generate_workout`            | Generate a structured workout with sport, type, and duration parameters  |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intervals-icu-mcp"
-version = "1.1.0"
+version = "1.1.1"
 description = "Model Context Protocol server for Intervals.icu — access training data, wellness metrics, and performance analysis from Claude and other LLMs."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
-authors = [{ name = "Heiko Kromminga" }]
+authors = [{ name = "Heiko Kromminga", email = "109036830+hhopke@users.noreply.github.com" }]
 keywords = [
     "intervals.icu",
     "mcp",
@@ -23,7 +23,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -44,8 +43,9 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/hhopke/intervals-icu-mcp"
 Repository = "https://github.com/hhopke/intervals-icu-mcp"
+Documentation = "https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md"
 Issues = "https://github.com/hhopke/intervals-icu-mcp/issues"
-Changelog = "https://github.com/hhopke/intervals-icu-mcp/blob/main/README.md#changelog"
+Changelog = "https://github.com/hhopke/intervals-icu-mcp/blob/main/CHANGELOG.md"
 
 [project.scripts]
 intervals-icu-mcp = "intervals_icu_mcp.server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "intervals-icu-mcp"
-version = "1.1.1"
+dynamic = ["version"]
 description = "Model Context Protocol server for Intervals.icu — access training data, wellness metrics, and performance analysis from Claude and other LLMs."
 readme = "README.md"
 license = "MIT"
@@ -52,8 +52,11 @@ intervals-icu-mcp = "intervals_icu_mcp.server:main"
 intervals-icu-mcp-auth = "intervals_icu_mcp.scripts.setup_auth:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [dependency-groups]
 dev = [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/hhopke/intervals-icu-mcp",
     "source": "github"
   },
-  "version": "1.0.1",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "intervals-icu-mcp",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,6 @@ wheels = [
 
 [[package]]
 name = "intervals-icu-mcp"
-version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "intervals-icu-mcp"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Shrinks README from 566 to ~270 lines by extracting reference material to dedicated files and collapsing duplicate install/client flavors into <details> blocks. All cross-repo links use absolute GitHub URLs so they resolve from PyPI, not just GitHub.

- New CHANGELOG.md (Keep-a-Changelog format)
- New docs/tools.md (full 51-tool inventory + Resources + Prompts)
- New docs/examples.md (full usage-example catalogue by category)
- README keeps Quick Start, one primary install path, and the big-three client configs expanded; alternate flavors collapsed under <details>

## Summary

<!-- What does this PR do, and why? If it closes an issue, write "Closes #123". -->

## Changes

<!-- A short bulleted list of the concrete changes. -->

-
-

## Checklist

- [ ] `make can-release` passes locally (tests, ruff, pyright)
- [ ] New tools have a corresponding respx-mocked test file in `tests/`
- [ ] Public-facing behavior changes are reflected in the README or `docs/`
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [ ] No API keys, athlete IDs, or other credentials are committed

## Test plan

<!-- How did you verify the change? e.g. unit tests added, tested live against a Claude Desktop session, etc. -->
