### PR TITLE
feat(events): full calendar category support with range fields and availability

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -7,7 +7,25 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Type aliases for common enums
 ActivityType = Literal["Ride", "Run", "Swim", "Walk", "Hike", "VirtualRide", "VirtualRun", "Other"]
-EventCategory = Literal["WORKOUT", "NOTE", "RACE", "GOAL"]
+EventCategory = Literal[
+    "WORKOUT",
+    "NOTE",
+    "RACE_A",
+    "RACE_B",
+    "RACE_C",
+    "TARGET",
+    "PLAN",
+    "HOLIDAY",
+    "SICK",
+    "INJURED",
+    "SET_EFTP",
+    "FITNESS_DAYS",
+    "SEASON_START",
+    "SET_FITNESS",
+    "RACE",
+    "GOAL",
+]
+TrainingAvailability = Literal["NORMAL", "LIMITED", "UNAVAILABLE"]
 
 
 # ==================== Athlete Models ====================
@@ -172,7 +190,8 @@ class Event(BaseModel):
 
     id: int
     start_date_local: str  # ISO-8601 date
-    category: str | None = None  # WORKOUT, NOTE, RACE, GOAL
+    end_date_local: str | None = None
+    category: str | None = None  # See EventCategory for valid values
     name: str | None = None
     description: str | None = None
     type: str | None = None
@@ -186,6 +205,10 @@ class Event(BaseModel):
     joules: int | None = None
     joules_above_ftp: int | None = Field(None, alias="joules_above_ftp")
     color: str | None = None
+    training_availability: str | None = None
+    show_as_note: bool | None = None
+    not_on_fitness_chart: bool | None = None
+    show_on_ctl_line: bool | None = None
     hide_from_athlete: bool | None = Field(None, alias="hide_from_athlete")
     athlete_cannot_edit: bool | None = Field(None, alias="athlete_cannot_edit")
     external_id: str | None = Field(None, alias="external_id")

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -7,13 +7,100 @@ from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
+from ..models import Event
 from ..response_builder import ResponseBuilder
+
+VALID_CATEGORIES = {
+    "WORKOUT",
+    "NOTE",
+    "RACE_A",
+    "RACE_B",
+    "RACE_C",
+    "TARGET",
+    "PLAN",
+    "HOLIDAY",
+    "SICK",
+    "INJURED",
+    "SET_EFTP",
+    "FITNESS_DAYS",
+    "SEASON_START",
+    "SET_FITNESS",
+}
+CATEGORY_ALIASES = {"RACE": "RACE_A", "GOAL": "TARGET"}
+VALID_AVAILABILITY = {"NORMAL", "LIMITED", "UNAVAILABLE"}
+RACE_CATEGORIES = {"RACE_A", "RACE_B", "RACE_C"}
+# Canonical Intervals.icu activity disciplines accepted by the API for the
+# `type` field. Must match models.ActivityType.
+ACTIVITY_TYPES_HINT = "Ride, Run, Swim, Walk, Hike, VirtualRide, VirtualRun, Other"
+
+
+def _normalize_category(category: str) -> tuple[str | None, str | None]:
+    """Normalize a category string to its canonical API value.
+
+    Uppercases the input, applies legacy aliases (RACE→RACE_A, GOAL→TARGET),
+    and validates against the API enum. Returns (normalized, error_message).
+    """
+    normalized = category.upper()
+    normalized = CATEGORY_ALIASES.get(normalized, normalized)
+    if normalized not in VALID_CATEGORIES:
+        valid = ", ".join(sorted(VALID_CATEGORIES))
+        return None, f"Invalid category. Must be one of: {valid}"
+    return normalized, None
+
+
+def _normalize_date(date_str: str) -> str:
+    """Normalize a date string to ISO-8601 (YYYY-MM-DDTHH:MM:SS).
+
+    Accepts YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS. Raises ValueError on bad input.
+    """
+    return datetime.fromisoformat(date_str).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _event_to_dict(event: Event) -> dict[str, Any]:
+    """Build the canonical tool response dict for an Event."""
+    result: dict[str, Any] = {
+        "id": event.id,
+        "start_date": event.start_date_local,
+        "name": event.name,
+        "category": event.category,
+    }
+
+    if event.end_date_local:
+        result["end_date"] = event.end_date_local
+    if event.description:
+        result["description"] = event.description
+    if event.type:
+        result["type"] = event.type
+    if event.moving_time:
+        result["duration_seconds"] = event.moving_time
+    if event.distance:
+        result["distance_meters"] = event.distance
+    if event.icu_training_load:
+        result["training_load"] = event.icu_training_load
+    if event.training_availability:
+        result["training_availability"] = event.training_availability
+    if event.color:
+        result["color"] = event.color
+    if event.show_as_note is not None:
+        result["show_as_note"] = event.show_as_note
+    if event.not_on_fitness_chart is not None:
+        result["not_on_fitness_chart"] = event.not_on_fitness_chart
+    if event.show_on_ctl_line is not None:
+        result["show_on_ctl_line"] = event.show_on_ctl_line
+
+    return result
 
 
 async def create_event(
     start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
     name: Annotated[str, "Event name"],
-    category: Annotated[str, "Event category: WORKOUT, NOTE, RACE, or GOAL"],
+    category: Annotated[
+        str,
+        "Event category. WORKOUT, NOTE, RACE_A/RACE_B/RACE_C (race tier), TARGET "
+        "(performance goal), PLAN, HOLIDAY (Urlaub), SICK (Krank), INJURED "
+        "(Verletzt), SET_EFTP, FITNESS_DAYS (Fitnesstage), SEASON_START (Saison), "
+        "SET_FITNESS. Legacy aliases RACE→RACE_A and GOAL→TARGET are accepted.",
+    ],
     description: Annotated[
         str | None,
         "Event description. For WORKOUT events, use Intervals.icu structured workout "
@@ -22,17 +109,45 @@ async def create_event(
         "resource for the complete syntax reference. Example: "
         "'Warmup\n- 10m ramp 50%-75%\n\nMain Set 3x\n- 5m 95%\n- 3m 55%\n\nCooldown\n- 10m 50%'",
     ] = None,
-    event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
+    event_type: Annotated[
+        str | None,
+        "Activity discipline (NOT the category). Must be one of: "
+        "Ride, Run, Swim, Walk, Hike, VirtualRide, VirtualRun, Other. "
+        "Required for RACE_A/RACE_B/RACE_C events — the API rejects races "
+        "without a discipline.",
+    ] = None,
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
     training_load: Annotated[int | None, "Planned training load"] = None,
+    end_date: Annotated[
+        str | None,
+        "End date in YYYY-MM-DD format. Use for ranged categories like INJURED, "
+        "SICK, HOLIDAY, SEASON_START to mark a multi-day block.",
+    ] = None,
+    training_availability: Annotated[
+        str | None,
+        "Training availability during the event: NORMAL (Verfügbar), LIMITED "
+        "(Begrenzt), or UNAVAILABLE (Nicht verfügbar). Typical for INJURED/SICK/"
+        "HOLIDAY blocks so the planner skips or scales workouts.",
+    ] = None,
+    color: Annotated[str | None, "Custom display color (hex string)"] = None,
+    show_as_note: Annotated[
+        bool | None, "Show event as a note marker on the fitness chart"
+    ] = None,
+    not_on_fitness_chart: Annotated[
+        bool | None, "Hide event entirely from the fitness chart"
+    ] = None,
+    show_on_ctl_line: Annotated[bool | None, "Render event on the CTL line"] = None,
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create a new calendar event (planned workout, note, race, or goal).
+    """Create a new calendar event.
 
-    Adds an event to your Intervals.icu calendar. Events can be workouts with
-    planned metrics, notes for tracking information, races, or training goals.
+    Supports the full Intervals.icu calendar category set: planned workouts, notes,
+    races (RACE_A/B/C tiers), performance targets, training plans, and life-event
+    blocks like INJURED, SICK, HOLIDAY, SEASON_START. Block-style categories
+    typically use start_date + end_date + training_availability so the planner
+    treats the affected days correctly.
 
     For WORKOUT events, the 'description' field accepts Intervals.icu structured
     workout syntax. The server automatically parses this text into a structured
@@ -42,12 +157,18 @@ async def create_event(
     Args:
         start_date: Date in ISO-8601 format (YYYY-MM-DD)
         name: Name of the event
-        category: Type of event - WORKOUT, NOTE, RACE, or GOAL
+        category: One of the categories listed in the parameter description
         description: For workouts, structured workout text (see workout-syntax resource)
         event_type: Activity type (e.g., "Ride", "Run", "Swim") for workouts
         duration_seconds: Planned duration for workouts
         distance_meters: Planned distance for workouts
         training_load: Planned training load for workouts
+        end_date: End date for ranged categories (INJURED, SICK, HOLIDAY, ...)
+        training_availability: NORMAL, LIMITED, or UNAVAILABLE
+        color: Custom color hex string
+        show_as_note: Show as a note on the fitness chart
+        not_on_fitness_chart: Hide from the fitness chart
+        show_on_ctl_line: Render on the CTL line
 
     Returns:
         JSON string with created event data
@@ -55,29 +176,53 @@ async def create_event(
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
 
-    # Validate category
-    valid_categories = ["WORKOUT", "NOTE", "RACE", "GOAL"]
-    if category.upper() not in valid_categories:
+    normalized_category, category_error = _normalize_category(category)
+    if category_error or normalized_category is None:
         return ResponseBuilder.build_error_response(
-            f"Invalid category. Must be one of: {', '.join(valid_categories)}",
+            category_error or "Invalid category",
             error_type="validation_error",
         )
 
-    # Validate and normalize date format (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
+    if normalized_category in RACE_CATEGORIES and not event_type:
+        return ResponseBuilder.build_error_response(
+            f"event_type is required for {normalized_category} events. "
+            f"Provide the activity discipline: {ACTIVITY_TYPES_HINT}.",
+            error_type="validation_error",
+        )
+
+    if training_availability is not None:
+        normalized_availability = training_availability.upper()
+        if normalized_availability not in VALID_AVAILABILITY:
+            return ResponseBuilder.build_error_response(
+                f"Invalid training_availability. Must be one of: "
+                f"{', '.join(sorted(VALID_AVAILABILITY))}",
+                error_type="validation_error",
+            )
+    else:
+        normalized_availability = None
+
     try:
-        start_date = datetime.fromisoformat(start_date).strftime("%Y-%m-%dT%H:%M:%S")
+        start_date = _normalize_date(start_date)
     except ValueError:
         return ResponseBuilder.build_error_response(
             "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
             error_type="validation_error",
         )
 
+    if end_date is not None:
+        try:
+            end_date = _normalize_date(end_date)
+        except ValueError:
+            return ResponseBuilder.build_error_response(
+                "Invalid end_date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
+                error_type="validation_error",
+            )
+
     try:
-        # Build event data
         event_data: dict[str, Any] = {
             "start_date_local": start_date,
             "name": name,
-            "category": category.upper(),
+            "category": normalized_category,
         }
 
         if description:
@@ -90,32 +235,28 @@ async def create_event(
             event_data["distance"] = distance_meters
         if training_load:
             event_data["icu_training_load"] = training_load
+        if end_date is not None:
+            event_data["end_date_local"] = end_date
+        if normalized_availability is not None:
+            event_data["training_availability"] = normalized_availability
+        if color is not None:
+            event_data["color"] = color
+        if show_as_note is not None:
+            event_data["show_as_note"] = show_as_note
+        if not_on_fitness_chart is not None:
+            event_data["not_on_fitness_chart"] = not_on_fitness_chart
+        if show_on_ctl_line is not None:
+            event_data["show_on_ctl_line"] = show_on_ctl_line
 
         async with ICUClient(config) as client:
             event = await client.create_event(event_data, athlete_id=athlete_id)
 
-            event_result: dict[str, Any] = {
-                "id": event.id,
-                "start_date": event.start_date_local,
-                "name": event.name,
-                "category": event.category,
-            }
-
-            if event.description:
-                event_result["description"] = event.description
-            if event.type:
-                event_result["type"] = event.type
-            if event.moving_time:
-                event_result["duration_seconds"] = event.moving_time
-            if event.distance:
-                event_result["distance_meters"] = event.distance
-            if event.icu_training_load:
-                event_result["training_load"] = event.icu_training_load
-
             return ResponseBuilder.build_response(
-                data=event_result,
+                data=_event_to_dict(event),
                 query_type="create_event",
-                metadata={"message": f"Successfully created {category.lower()}: {name}"},
+                metadata={
+                    "message": f"Successfully created {normalized_category.lower()}: {name}"
+                },
             )
 
     except ICUAPIError as e:
@@ -135,13 +276,22 @@ async def update_event(
     duration_seconds: Annotated[int | None, "Updated duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Updated distance in meters"] = None,
     training_load: Annotated[int | None, "Updated training load"] = None,
+    end_date: Annotated[str | None, "Updated end date (YYYY-MM-DD)"] = None,
+    training_availability: Annotated[
+        str | None, "Updated training availability: NORMAL, LIMITED, or UNAVAILABLE"
+    ] = None,
+    color: Annotated[str | None, "Updated color (hex string)"] = None,
+    show_as_note: Annotated[bool | None, "Show event as a note on the fitness chart"] = None,
+    not_on_fitness_chart: Annotated[bool | None, "Hide event from the fitness chart"] = None,
+    show_on_ctl_line: Annotated[bool | None, "Render event on the CTL line"] = None,
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing calendar event.
 
     Modifies one or more fields of an existing event. Only provide the fields
-    you want to change - other fields will remain unchanged.
+    you want to change - other fields will remain unchanged. Use end_date and
+    training_availability to extend or update INJURED/SICK/HOLIDAY blocks.
 
     Args:
         event_id: ID of the event to update
@@ -152,6 +302,12 @@ async def update_event(
         duration_seconds: New planned duration
         distance_meters: New planned distance
         training_load: New planned training load
+        end_date: New end date for ranged events
+        training_availability: NORMAL, LIMITED, or UNAVAILABLE
+        color: New color hex string
+        show_as_note: Show as a note on the fitness chart
+        not_on_fitness_chart: Hide from the fitness chart
+        show_on_ctl_line: Render on the CTL line
 
     Returns:
         JSON string with updated event data
@@ -159,18 +315,36 @@ async def update_event(
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
 
-    # Validate and normalize date format if provided (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
-    if start_date:
+    if start_date is not None:
         try:
-            start_date = datetime.fromisoformat(start_date).strftime("%Y-%m-%dT%H:%M:%S")
+            start_date = _normalize_date(start_date)
         except ValueError:
             return ResponseBuilder.build_error_response(
                 "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
                 error_type="validation_error",
             )
 
+    if end_date is not None:
+        try:
+            end_date = _normalize_date(end_date)
+        except ValueError:
+            return ResponseBuilder.build_error_response(
+                "Invalid end_date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
+                error_type="validation_error",
+            )
+
+    if training_availability is not None:
+        normalized_availability = training_availability.upper()
+        if normalized_availability not in VALID_AVAILABILITY:
+            return ResponseBuilder.build_error_response(
+                f"Invalid training_availability. Must be one of: "
+                f"{', '.join(sorted(VALID_AVAILABILITY))}",
+                error_type="validation_error",
+            )
+    else:
+        normalized_availability = None
+
     try:
-        # Build update data (only include provided fields)
         event_data: dict[str, Any] = {}
 
         if name is not None:
@@ -187,6 +361,18 @@ async def update_event(
             event_data["distance"] = distance_meters
         if training_load is not None:
             event_data["icu_training_load"] = training_load
+        if end_date is not None:
+            event_data["end_date_local"] = end_date
+        if normalized_availability is not None:
+            event_data["training_availability"] = normalized_availability
+        if color is not None:
+            event_data["color"] = color
+        if show_as_note is not None:
+            event_data["show_as_note"] = show_as_note
+        if not_on_fitness_chart is not None:
+            event_data["not_on_fitness_chart"] = not_on_fitness_chart
+        if show_on_ctl_line is not None:
+            event_data["show_on_ctl_line"] = show_on_ctl_line
 
         if not event_data:
             return ResponseBuilder.build_error_response(
@@ -197,26 +383,8 @@ async def update_event(
         async with ICUClient(config) as client:
             event = await client.update_event(event_id, event_data, athlete_id=athlete_id)
 
-            event_result: dict[str, Any] = {
-                "id": event.id,
-                "start_date": event.start_date_local,
-                "name": event.name,
-                "category": event.category,
-            }
-
-            if event.description:
-                event_result["description"] = event.description
-            if event.type:
-                event_result["type"] = event.type
-            if event.moving_time:
-                event_result["duration_seconds"] = event.moving_time
-            if event.distance:
-                event_result["distance_meters"] = event.distance
-            if event.icu_training_load:
-                event_result["training_load"] = event.icu_training_load
-
             return ResponseBuilder.build_response(
-                data=event_result,
+                data=_event_to_dict(event),
                 query_type="update_event",
                 metadata={"message": f"Successfully updated event {event_id}"},
             )
@@ -274,23 +442,27 @@ async def delete_event(
 async def bulk_create_events(
     events: Annotated[
         str,
-        "JSON string containing array of events. Each event should have: "
-        "start_date_local, name, category, and optional fields like description, "
-        "type, moving_time, distance, icu_training_load. For WORKOUT events, "
-        "include structured workout syntax in the 'description' field "
-        "(see intervals-icu://workout-syntax resource for syntax reference).",
+        "JSON array of events. Required per event: start_date_local, name, category. "
+        "Optional: description, type, moving_time, distance, icu_training_load, "
+        "end_date_local (ranged categories), training_availability "
+        "(NORMAL/LIMITED/UNAVAILABLE), color, show_as_note, not_on_fitness_chart, "
+        "show_on_ctl_line. Categories: WORKOUT, NOTE, RACE_A/B/C, TARGET, PLAN, "
+        "HOLIDAY, SICK, INJURED, SET_EFTP, FITNESS_DAYS, SEASON_START, SET_FITNESS "
+        "(legacy RACE→RACE_A and GOAL→TARGET aliases accepted). For WORKOUT events, "
+        "include structured workout syntax in 'description' (see "
+        "intervals-icu://workout-syntax resource).",
     ],
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Create multiple calendar events in a single operation.
 
-    This is more efficient than creating events one at a time. Provide a JSON array
-    of event objects, each with the same structure as create_event.
+    More efficient than creating events one at a time. Provide a JSON array
+    of event objects with the same fields accepted by create_event.
 
     For WORKOUT events, include Intervals.icu structured workout syntax in the
-    'description' field. The server automatically parses workout text into structured
-    workouts. Read the intervals-icu://workout-syntax resource for the complete syntax.
+    'description' field. Read the intervals-icu://workout-syntax resource for the
+    complete syntax.
 
     Args:
         events: JSON array of event objects to create
@@ -304,7 +476,6 @@ async def bulk_create_events(
     try:
         import json
 
-        # Parse the JSON string
         try:
             parsed_data = json.loads(events)
         except json.JSONDecodeError as e:
@@ -317,11 +488,8 @@ async def bulk_create_events(
                 "Events must be a JSON array", error_type="validation_error"
             )
 
-        # Type cast after validation
         events_data: list[dict[str, Any]] = parsed_data  # type: ignore[assignment]
 
-        # Validate each event
-        valid_categories = ["WORKOUT", "NOTE", "RACE", "GOAL"]
         for i, event_data in enumerate(events_data):
             if "start_date_local" not in event_data:
                 return ResponseBuilder.build_error_response(
@@ -337,50 +505,56 @@ async def bulk_create_events(
                     f"Event {i}: Missing required field 'category'",
                     error_type="validation_error",
                 )
-            if event_data["category"].upper() not in valid_categories:
+
+            normalized_category, category_error = _normalize_category(event_data["category"])
+            if category_error or normalized_category is None:
                 return ResponseBuilder.build_error_response(
-                    f"Event {i}: Invalid category. Must be one of: {', '.join(valid_categories)}",
+                    f"Event {i}: {category_error or 'Invalid category'}",
+                    error_type="validation_error",
+                )
+            event_data["category"] = normalized_category
+
+            if normalized_category in RACE_CATEGORIES and not event_data.get("type"):
+                return ResponseBuilder.build_error_response(
+                    f"Event {i}: 'type' is required for {normalized_category} events. "
+                    f"Provide the activity discipline: {ACTIVITY_TYPES_HINT}.",
                     error_type="validation_error",
                 )
 
-            # Normalize category to uppercase
-            event_data["category"] = event_data["category"].upper()
-
-            # Validate and normalize date format (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
             try:
-                event_data["start_date_local"] = datetime.fromisoformat(
-                    event_data["start_date_local"]
-                ).strftime("%Y-%m-%dT%H:%M:%S")
+                event_data["start_date_local"] = _normalize_date(event_data["start_date_local"])
             except ValueError:
                 return ResponseBuilder.build_error_response(
                     f"Event {i}: Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
                     error_type="validation_error",
                 )
 
+            if "end_date_local" in event_data and event_data["end_date_local"] is not None:
+                try:
+                    event_data["end_date_local"] = _normalize_date(event_data["end_date_local"])
+                except ValueError:
+                    return ResponseBuilder.build_error_response(
+                        f"Event {i}: Invalid end_date_local format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
+                        error_type="validation_error",
+                    )
+
+            if (
+                "training_availability" in event_data
+                and event_data["training_availability"] is not None
+            ):
+                availability = str(event_data["training_availability"]).upper()
+                if availability not in VALID_AVAILABILITY:
+                    return ResponseBuilder.build_error_response(
+                        f"Event {i}: Invalid training_availability. Must be one of: "
+                        f"{', '.join(sorted(VALID_AVAILABILITY))}",
+                        error_type="validation_error",
+                    )
+                event_data["training_availability"] = availability
+
         async with ICUClient(config) as client:
             created_events = await client.bulk_create_events(events_data, athlete_id=athlete_id)
 
-            events_result: list[dict[str, Any]] = []
-            for event in created_events:
-                event_info: dict[str, Any] = {
-                    "id": event.id,
-                    "start_date": event.start_date_local,
-                    "name": event.name,
-                    "category": event.category,
-                }
-
-                if event.description:
-                    event_info["description"] = event.description
-                if event.type:
-                    event_info["type"] = event.type
-                if event.moving_time:
-                    event_info["duration_seconds"] = event.moving_time
-                if event.distance:
-                    event_info["distance_meters"] = event.distance
-                if event.icu_training_load:
-                    event_info["training_load"] = event.icu_training_load
-
-                events_result.append(event_info)
+            events_result = [_event_to_dict(event) for event in created_events]
 
             return ResponseBuilder.build_response(
                 data={"events": events_result},

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -108,6 +108,12 @@ async def get_calendar_events(
                     if event.icu_intensity:
                         event_item["intensity_factor"] = event.icu_intensity
 
+                # Ranged events (INJURED, SICK, HOLIDAY, SEASON_START, ...)
+                if event.end_date_local:
+                    event_item["end_date"] = event.end_date_local
+                if event.training_availability:
+                    event_item["training_availability"] = event.training_availability
+
                 # Description
                 if event.description:
                     event_item["description"] = event.description.strip()
@@ -116,9 +122,14 @@ async def get_calendar_events(
 
             # Calculate summary
             workout_count = sum(1 for e in events if e.category == "WORKOUT")
-            race_count = sum(1 for e in events if e.category == "RACE")
+            race_count = sum(1 for e in events if e.category in ("RACE_A", "RACE_B", "RACE_C"))
             note_count = sum(1 for e in events if e.category == "NOTE")
-            goal_count = sum(1 for e in events if e.category == "GOAL")
+            target_count = sum(1 for e in events if e.category == "TARGET")
+            block_count = sum(
+                1
+                for e in events
+                if e.category in ("INJURED", "SICK", "HOLIDAY", "SEASON_START")
+            )
 
             summary = {
                 "total_events": len(events),
@@ -126,7 +137,8 @@ async def get_calendar_events(
                     "workouts": workout_count,
                     "races": race_count,
                     "notes": note_count,
-                    "goals": goal_count,
+                    "targets": target_count,
+                    "blocks": block_count,
                 },
             }
 
@@ -319,6 +331,20 @@ async def get_event(
                 fitness["atl"] = round(event.icu_atl, 1)
             if fitness:
                 event_data["fitness_context"] = fitness
+
+            # Date range and availability (INJURED/SICK/HOLIDAY/SEASON_START)
+            if event.end_date_local:
+                event_data["end_date"] = event.end_date_local
+            if event.training_availability:
+                event_data["training_availability"] = event.training_availability
+
+            # Display flags
+            if event.show_as_note is not None:
+                event_data["show_as_note"] = event.show_as_note
+            if event.not_on_fitness_chart is not None:
+                event_data["not_on_fitness_chart"] = event.not_on_fitness_chart
+            if event.show_on_ctl_line is not None:
+                event_data["show_on_ctl_line"] = event.show_on_ctl_line
 
             # Metadata
             if event.color:

--- a/tests/test_event_tools.py
+++ b/tests/test_event_tools.py
@@ -130,6 +130,251 @@ class TestEventTools:
         response = json.loads(result)
         assert "error" in response
         assert "Invalid category" in response["error"]["message"]
+        # Error message lists the new category enum
+        assert "INJURED" in response["error"]["message"]
+        assert "HOLIDAY" in response["error"]["message"]
+
+    async def test_create_event_injury_with_date_range(self, mock_config, respx_mock):
+        """INJURED block with end_date and training_availability is forwarded correctly."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.post("/athlete/i123456/events").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 5001,
+                    "name": "Knieprobleme",
+                    "start_date_local": "2026-04-25T00:00:00",
+                    "end_date_local": "2026-05-05T00:00:00",
+                    "category": "INJURED",
+                    "training_availability": "LIMITED",
+                },
+            )
+        )
+
+        result = await create_event(
+            start_date="2026-04-25",
+            name="Knieprobleme",
+            category="INJURED",
+            end_date="2026-05-05",
+            training_availability="limited",
+            ctx=mock_ctx,
+        )
+
+        # Outgoing payload assertions
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["category"] == "INJURED"
+        assert sent["start_date_local"] == "2026-04-25T00:00:00"
+        assert sent["end_date_local"] == "2026-05-05T00:00:00"
+        assert sent["training_availability"] == "LIMITED"
+
+        # Response shape
+        response = json.loads(result)
+        assert response["data"]["category"] == "INJURED"
+        assert response["data"]["end_date"] == "2026-05-05T00:00:00"
+        assert response["data"]["training_availability"] == "LIMITED"
+
+    async def test_create_event_holiday_with_unavailable(self, mock_config, respx_mock):
+        """HOLIDAY with training_availability=UNAVAILABLE is accepted."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.post("/athlete/i123456/events").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 5002,
+                    "name": "Spring Break",
+                    "start_date_local": "2026-05-01T00:00:00",
+                    "end_date_local": "2026-05-08T00:00:00",
+                    "category": "HOLIDAY",
+                    "training_availability": "UNAVAILABLE",
+                },
+            )
+        )
+
+        await create_event(
+            start_date="2026-05-01",
+            name="Spring Break",
+            category="HOLIDAY",
+            end_date="2026-05-08",
+            training_availability="UNAVAILABLE",
+            ctx=mock_ctx,
+        )
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["category"] == "HOLIDAY"
+        assert sent["training_availability"] == "UNAVAILABLE"
+
+    async def test_create_event_legacy_race_alias(self, mock_config, respx_mock):
+        """Legacy 'RACE' is normalized to 'RACE_A' before sending."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.post("/athlete/i123456/events").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 5003,
+                    "name": "Goal Race",
+                    "start_date_local": "2026-06-01T00:00:00",
+                    "category": "RACE_A",
+                    "type": "Run",
+                },
+            )
+        )
+
+        await create_event(
+            start_date="2026-06-01",
+            name="Goal Race",
+            category="RACE",
+            event_type="Run",
+            ctx=mock_ctx,
+        )
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["category"] == "RACE_A"
+        assert sent["type"] == "Run"
+
+    async def test_create_event_race_without_type_is_rejected(self, mock_config):
+        """Validation: RACE_A/B/C without event_type returns helpful error pre-flight."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await create_event(
+            start_date="2026-09-13",
+            name="Otztaler",
+            category="RACE_A",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+        message = response["error"]["message"]
+        assert "event_type" in message
+        assert "RACE_A" in message
+        # Hint lists the valid disciplines
+        assert "Ride" in message and "Run" in message
+
+    async def test_bulk_create_events_race_without_type_is_rejected(self, mock_config):
+        """Validation: bulk RACE_A entry without 'type' is rejected pre-flight."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        events_payload = json.dumps(
+            [
+                {
+                    "start_date_local": "2026-09-13",
+                    "name": "Otztaler",
+                    "category": "RACE_A",
+                },
+            ]
+        )
+
+        result = await bulk_create_events(events=events_payload, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+        assert "type" in response["error"]["message"]
+        assert "RACE_A" in response["error"]["message"]
+
+    async def test_create_event_legacy_goal_alias(self, mock_config, respx_mock):
+        """Legacy 'GOAL' is normalized to 'TARGET' before sending."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.post("/athlete/i123456/events").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 5004,
+                    "name": "Sub-3 marathon",
+                    "start_date_local": "2026-09-01T00:00:00",
+                    "category": "TARGET",
+                },
+            )
+        )
+
+        await create_event(
+            start_date="2026-09-01",
+            name="Sub-3 marathon",
+            category="goal",
+            ctx=mock_ctx,
+        )
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["category"] == "TARGET"
+
+    async def test_create_event_rejects_invalid_availability(self, mock_config):
+        """Validation: bogus training_availability is rejected without API call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await create_event(
+            start_date="2026-04-25",
+            name="Knee",
+            category="INJURED",
+            training_availability="MAYBE",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+        assert "training_availability" in response["error"]["message"]
+
+    async def test_create_event_rejects_invalid_end_date(self, mock_config):
+        """Validation: malformed end_date is rejected without API call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await create_event(
+            start_date="2026-04-25",
+            name="Knee",
+            category="INJURED",
+            end_date="not-a-date",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+        assert "end_date" in response["error"]["message"]
+
+    async def test_update_event_can_set_end_date_and_availability(
+        self, mock_config, respx_mock
+    ):
+        """Updating an injury block to extend its end_date and change availability."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.put("/athlete/i123456/events/5001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 5001,
+                    "name": "Knieprobleme",
+                    "start_date_local": "2026-04-25T00:00:00",
+                    "end_date_local": "2026-05-15T00:00:00",
+                    "category": "INJURED",
+                    "training_availability": "NORMAL",
+                },
+            )
+        )
+
+        result = await update_event(
+            event_id=5001,
+            end_date="2026-05-15",
+            training_availability="NORMAL",
+            ctx=mock_ctx,
+        )
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["end_date_local"] == "2026-05-15T00:00:00"
+        assert sent["training_availability"] == "NORMAL"
+
+        response = json.loads(result)
+        assert response["data"]["end_date"] == "2026-05-15T00:00:00"
+        assert response["data"]["training_availability"] == "NORMAL"
 
     async def test_create_event_rejects_invalid_date(self, mock_config):
         """Validation: malformed start_date returns an error without hitting the API."""
@@ -224,6 +469,74 @@ class TestEventTools:
         assert len(response["data"]["events"]) == 2
         assert response["metadata"]["count"] == 2
         assert response["metadata"]["message"] == "Successfully created 2 events"
+
+    async def test_bulk_create_events_supports_injury_block(self, mock_config, respx_mock):
+        """Bulk create forwards INJURED + end_date_local + training_availability."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.post("/athlete/i123456/events/bulk").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": 6001,
+                        "start_date_local": "2026-04-25T00:00:00",
+                        "end_date_local": "2026-05-05T00:00:00",
+                        "name": "Knee",
+                        "category": "INJURED",
+                        "training_availability": "LIMITED",
+                    },
+                ],
+            )
+        )
+
+        events_payload = json.dumps(
+            [
+                {
+                    "start_date_local": "2026-04-25",
+                    "end_date_local": "2026-05-05",
+                    "name": "Knee",
+                    "category": "injured",
+                    "training_availability": "limited",
+                },
+            ]
+        )
+
+        result = await bulk_create_events(events=events_payload, ctx=mock_ctx)
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent[0]["category"] == "INJURED"
+        assert sent[0]["start_date_local"] == "2026-04-25T00:00:00"
+        assert sent[0]["end_date_local"] == "2026-05-05T00:00:00"
+        assert sent[0]["training_availability"] == "LIMITED"
+
+        response = json.loads(result)
+        assert response["data"]["events"][0]["category"] == "INJURED"
+        assert response["data"]["events"][0]["end_date"] == "2026-05-05T00:00:00"
+        assert response["data"]["events"][0]["training_availability"] == "LIMITED"
+
+    async def test_bulk_create_events_rejects_invalid_availability(self, mock_config):
+        """Validation: bogus training_availability in a bulk entry is rejected."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        events_payload = json.dumps(
+            [
+                {
+                    "start_date_local": "2026-04-25",
+                    "name": "Knee",
+                    "category": "INJURED",
+                    "training_availability": "SOMETIMES",
+                },
+            ]
+        )
+
+        result = await bulk_create_events(events=events_payload, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+        assert "training_availability" in response["error"]["message"]
 
     async def test_bulk_create_events_rejects_invalid_json(self, mock_config):
         """Validation: non-JSON input is rejected before any API call."""


### PR DESCRIPTION
## Summary
- Expand event categories from 4 to all 14 API enum values (INJURED, SICK, HOLIDAY, SEASON_START, RACE_A/B/C, TARGET, PLAN, SET_EFTP, FITNESS_DAYS, SET_FITNESS)
- Add `end_date`, `training_availability`, `show_as_note`, `not_on_fitness_chart`, `show_on_ctl_line` fields to create/update/bulk tools and read responses
- Legacy `RACE`→`RACE_A` and `GOAL`→`TARGET` aliases preserved for backwards compat
- Pre-flight validation: RACE_A/B/C without `event_type` returns clear error listing valid disciplines

## Test plan
- [x] `make can-release` passes (84 tests)
- [x] Manual: create INJURED block with `end_date` + `training_availability=LIMITED`, verify in Intervals.icu UI
- [x] Manual: create RACE_A with `event_type="Ride"`, verify created correctly
- [x] Manual: verify `get_calendar_events` returns `end_date` and `training_availability` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)