### PR TITLE
feat(tools): add activity messages and custom items tool categories

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Check for changes and create PR
         uses: peter-evans/create-pull-request@v8
         with:
+          sign-commits: true
           commit-message: "chore: update intervals.icu OpenAPI specification"
           title: "chore: update intervals.icu OpenAPI specification"
           body: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Intervals.icu — provides 51 tools, 2 resources, and 7 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs.
+MCP (Model Context Protocol) server for Intervals.icu — provides 58 tools, 2 resources, and 7 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs.
 
 - **Language**: Python 3.11+
 - **Framework**: FastMCP
@@ -37,7 +37,7 @@ make docker/run       # Run Docker container
 | Auth | `auth.py` | Loads credentials from `.env` |
 | Response | `response_builder.py` | Consistent JSON structure (data/analysis/metadata) |
 | Models | `models.py` | Pydantic models for API responses |
-| Tools | `tools/` | 11 tool modules (see below) |
+| Tools | `tools/` | 13 tool modules (see below) |
 
 **For detailed architecture**: see `docs/architecture.md`
 
@@ -45,15 +45,17 @@ make docker/run       # Run Docker container
 
 1. `activities.py` — Query/manage activities
 2. `activity_analysis.py` — Streams, intervals, best efforts
-3. `athlete.py` — Profile, fitness metrics (CTL/ATL/TSB)
-4. `wellness.py` — HRV, sleep, recovery
-5. `events.py` — Calendar queries
-6. `event_management.py` — Create/update/delete events
-7. `performance.py` — Power/HR/pace curves
-8. `curves.py` — HR and pace curve analysis
-9. `workout_library.py` — Browse workout folders and plans
-10. `gear.py` — Manage gear and reminders
-11. `sport_settings.py` — FTP, FTHR, pace thresholds
+3. `activity_messages.py` — Notes/comments on activities
+4. `athlete.py` — Profile, fitness metrics (CTL/ATL/TSB)
+5. `wellness.py` — HRV, sleep, recovery
+6. `events.py` — Calendar queries
+7. `event_management.py` — Create/update/delete events
+8. `performance.py` — Power/HR/pace curves
+9. `curves.py` — HR and pace curve analysis
+10. `workout_library.py` — Browse workout folders and plans
+11. `gear.py` — Manage gear and reminders
+12. `sport_settings.py` — FTP, FTHR, pace thresholds
+13. `custom_items.py` — Charts, custom fields, zones, etc.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-51 tools spanning activities, activity analysis, athlete profile, wellness, events/calendar, performance curves, workout library, gear, and sport settings — plus 2 MCP Resources (athlete profile, workout syntax reference) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
+58 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 2 MCP Resources (athlete profile, workout syntax reference) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
 
 ## Quick Start
 
@@ -280,12 +280,13 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 
 ## Available Tools
 
-51 tools, 2 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
+58 tools, 2 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
 
 | Category | Tools | Summary |
 |---|---|---|
 | [Activities](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activities-12-tools) | 12 | Query, search, update, delete, download activities |
 | [Activity Analysis](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activity-analysis-8-tools) | 8 | Streams, intervals, best efforts, histograms |
+| [Activity Messages](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activity-messages-2-tools) | 2 | Read and post notes/comments/coach feedback on activities |
 | [Athlete](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#athlete-2-tools) | 2 | Profile and CTL/ATL/TSB fitness analysis |
 | [Wellness](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#wellness-3-tools) | 3 | HRV, sleep, recovery metrics |
 | [Events / Calendar](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#events--calendar-10-tools) | 10 | Planned workouts, races, notes (bulk ops supported) |
@@ -293,6 +294,7 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 | [Workout Library](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#workout-library-2-tools) | 2 | Browse workout folders and training plans |
 | [Gear Management](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#gear-management-6-tools) | 6 | Track equipment and maintenance reminders |
 | [Sport Settings](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#sport-settings-5-tools) | 5 | FTP, FTHR, pace thresholds, and zones |
+| [Custom Items](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#custom-items-5-tools) | 5 | User customizations: custom charts, fields, zones, dashboard panels |
 
 ## Documentation
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool, Resource, and Prompt Reference
 
-Complete inventory of everything the Intervals.icu MCP server exposes: 51 tools across 9 categories, 2 MCP Resources, and 7 MCP Prompts.
+Complete inventory of everything the Intervals.icu MCP server exposes: 58 tools across 11 categories, 2 MCP Resources, and 7 MCP Prompts.
 
 ## Tools
 
@@ -33,6 +33,15 @@ Complete inventory of everything the Intervals.icu MCP server exposes: 51 tools 
 | `icu_get_hr_histogram`       | Get heart rate distribution histogram for an activity         |
 | `icu_get_pace_histogram`     | Get pace distribution histogram for an activity               |
 | `icu_get_gap_histogram`      | Get grade-adjusted pace histogram for an activity             |
+
+### Activity Messages (2 tools)
+
+The threaded notes/comments shown under an activity — the user's own training notes, comments from followers, or coach feedback.
+
+| Tool                       | Description                                                |
+| -------------------------- | ---------------------------------------------------------- |
+| `icu_get_activity_messages`    | Read notes/comments/coach feedback on a specific activity  |
+| `icu_add_activity_message`     | Post a note or comment on a specific activity              |
 
 ### Athlete (2 tools)
 
@@ -99,6 +108,18 @@ Complete inventory of everything the Intervals.icu MCP server exposes: 51 tools 
 | `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
 | `icu_create_sport_settings` | Create new sport-specific settings                      |
 | `icu_delete_sport_settings` | Delete sport-specific settings                          |
+
+### Custom Items (5 tools)
+
+The user's personal additions to their account: custom charts on dashboards, custom data fields on wellness/activities/intervals, custom power/HR/pace zone configurations, custom activity panels, and custom computed streams. The Intervals.icu API umbrella name is "custom items".
+
+| Tool                    | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `icu_get_custom_items`      | List the user's custom additions (charts, fields, zones, panels, etc.)     |
+| `icu_get_custom_item`       | Fetch the full configuration of one custom addition by ID                  |
+| `icu_create_custom_item`    | Add a new custom chart, field, zones config, or dashboard panel            |
+| `icu_update_custom_item`    | Modify an existing custom addition (rename, reconfigure, change visibility)|
+| `icu_delete_custom_item`    | Permanently remove a custom addition                                       |
 
 ## MCP Resources
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -601,7 +601,7 @@ class ICUClient:
             Response dictionary confirmation
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        
+
         payload: dict[str, Any] = {
             "folder_id": folder_id,
             "start_date_local": start_date_local,
@@ -805,7 +805,7 @@ class ICUClient:
             "PUT",
             f"/activity/{activity_id}/streams.csv",
             content=csv_data.encode("utf-8"),
-            headers={"Content-Type": "text/csv"}
+            headers={"Content-Type": "text/csv"},
         )
         try:
             return response.json()
@@ -1266,3 +1266,119 @@ class ICUClient:
         )
         adapter = TypeAdapter(list[Event])
         return adapter.validate_python(response.json())
+
+    # ==================== Activity Messages Endpoints ====================
+
+    async def get_activity_messages(self, activity_id: str) -> list[dict[str, Any]]:
+        """List messages (notes/comments) for an activity.
+
+        Args:
+            activity_id: Activity ID
+
+        Returns:
+            List of message dicts
+        """
+        response = await self._request("GET", f"/activity/{activity_id}/messages")
+        result: list[dict[str, Any]] = response.json()
+        return result
+
+    async def add_activity_message(self, activity_id: str, content: str) -> dict[str, Any]:
+        """Add a message (note/comment) to an activity.
+
+        Args:
+            activity_id: Activity ID
+            content: Message content
+
+        Returns:
+            Response dict (typically {"id": <new message id>})
+        """
+        response = await self._request(
+            "POST", f"/activity/{activity_id}/messages", json={"content": content}
+        )
+        result: dict[str, Any] = response.json()
+        return result
+
+    # ==================== Custom Items Endpoints ====================
+
+    async def get_custom_items(self, athlete_id: str | None = None) -> list[dict[str, Any]]:
+        """List custom items (charts, custom fields, zones, etc.) for an athlete.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of custom item dicts
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/custom-item")
+        result: list[dict[str, Any]] = response.json()
+        return result
+
+    async def get_custom_item(self, item_id: int, athlete_id: str | None = None) -> dict[str, Any]:
+        """Get a single custom item by ID.
+
+        Args:
+            item_id: Custom item ID
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Custom item dict
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/custom-item/{item_id}")
+        result: dict[str, Any] = response.json()
+        return result
+
+    async def create_custom_item(
+        self, item_data: dict[str, Any], athlete_id: str | None = None
+    ) -> dict[str, Any]:
+        """Create a custom item.
+
+        Args:
+            item_data: Custom item payload (must include name + type)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Created custom item dict
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("POST", f"/athlete/{athlete_id}/custom-item", json=item_data)
+        result: dict[str, Any] = response.json()
+        return result
+
+    async def update_custom_item(
+        self,
+        item_id: int,
+        item_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a custom item.
+
+        Args:
+            item_id: Custom item ID
+            item_data: Partial custom item payload (only fields to update)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Updated custom item dict
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "PUT", f"/athlete/{athlete_id}/custom-item/{item_id}", json=item_data
+        )
+        result: dict[str, Any] = response.json()
+        return result
+
+    async def delete_custom_item(self, item_id: int, athlete_id: str | None = None) -> bool:
+        """Delete a custom item.
+
+        Args:
+            item_id: Custom item ID
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            True if deletion was successful
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        await self._request("DELETE", f"/athlete/{athlete_id}/custom-item/{item_id}")
+        return True

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -42,8 +42,16 @@ from .tools.activity_analysis import (
     get_power_histogram,
     search_intervals,
 )
+from .tools.activity_messages import add_activity_message, get_activity_messages
 from .tools.athlete import get_athlete_profile, get_fitness_summary
 from .tools.curves import get_hr_curves, get_pace_curves
+from .tools.custom_items import (
+    create_custom_item,
+    delete_custom_item,
+    get_custom_item,
+    get_custom_items,
+    update_custom_item,
+)
 from .tools.event_management import (
     apply_training_plan,
     bulk_create_events,
@@ -76,224 +84,546 @@ from .tools.workout_library import get_workout_library, get_workouts_in_folder
 # Register activity tools
 mcp.tool(
     name="icu_get_recent_activities",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_recent_activities)
 mcp.tool(
     name="icu_get_activity_details",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_activity_details)
 mcp.tool(
     name="icu_search_activities",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(search_activities)
 mcp.tool(
     name="icu_search_activities_full",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(search_activities_full)
 mcp.tool(
     name="icu_get_activities_around",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_activities_around)
 mcp.tool(
     name="icu_update_activity",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_activity)
 mcp.tool(
     name="icu_update_activity_streams",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(update_activity_streams)
 mcp.tool(
     name="icu_bulk_create_manual_activities",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(bulk_create_manual_activities)
 mcp.tool(
     name="icu_delete_activity",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(delete_activity)
 mcp.tool(
     name="icu_download_activity_file",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(download_activity_file)
 mcp.tool(
     name="icu_download_fit_file",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(download_fit_file)
 mcp.tool(
     name="icu_download_gpx_file",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(download_gpx_file)
 
 # Register activity analysis tools
 mcp.tool(
     name="icu_get_activity_streams",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_activity_streams)
 mcp.tool(
     name="icu_get_activity_intervals",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_activity_intervals)
 mcp.tool(
     name="icu_get_best_efforts",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_best_efforts)
 mcp.tool(
     name="icu_search_intervals",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(search_intervals)
 mcp.tool(
     name="icu_get_power_histogram",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_power_histogram)
 mcp.tool(
     name="icu_get_hr_histogram",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_hr_histogram)
 mcp.tool(
     name="icu_get_pace_histogram",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_pace_histogram)
 mcp.tool(
     name="icu_get_gap_histogram",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_gap_histogram)
 
 # Register athlete tools
 mcp.tool(
     name="icu_get_athlete_profile",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_athlete_profile)
 mcp.tool(
     name="icu_get_fitness_summary",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_fitness_summary)
 
 # Register wellness tools
 mcp.tool(
     name="icu_get_wellness_data",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_wellness_data)
 mcp.tool(
     name="icu_get_wellness_for_date",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_wellness_for_date)
 mcp.tool(
     name="icu_update_wellness",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_wellness)
 
 # Register event/calendar tools
 mcp.tool(
     name="icu_get_calendar_events",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_calendar_events)
 mcp.tool(
     name="icu_get_upcoming_workouts",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_upcoming_workouts)
 mcp.tool(
     name="icu_get_event",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_event)
 mcp.tool(
     name="icu_create_event",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(create_event)
 mcp.tool(
     name="icu_update_event",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_event)
 mcp.tool(
     name="icu_delete_event",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(delete_event)
 mcp.tool(
     name="icu_bulk_create_events",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(bulk_create_events)
 mcp.tool(
     name="icu_bulk_delete_events",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(bulk_delete_events)
 mcp.tool(
     name="icu_duplicate_events",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(duplicate_events)
 mcp.tool(
     name="icu_apply_training_plan",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(apply_training_plan)
 
 # Register performance/curve tools
 mcp.tool(
     name="icu_get_power_curves",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_power_curves)
 mcp.tool(
     name="icu_get_hr_curves",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_hr_curves)
 mcp.tool(
     name="icu_get_pace_curves",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_pace_curves)
 
 # Register workout library tools
 mcp.tool(
     name="icu_get_workout_library",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_workout_library)
 mcp.tool(
     name="icu_get_workouts_in_folder",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_workouts_in_folder)
 
 # Register gear management tools
 mcp.tool(
     name="icu_get_gear_list",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_gear_list)
 mcp.tool(
     name="icu_create_gear",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(create_gear)
 mcp.tool(
     name="icu_update_gear",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_gear)
 mcp.tool(
     name="icu_delete_gear",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(delete_gear)
 mcp.tool(
     name="icu_create_gear_reminder",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(create_gear_reminder)
 mcp.tool(
     name="icu_update_gear_reminder",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_gear_reminder)
 
 # Register sport settings tools
 mcp.tool(
     name="icu_get_sport_settings",
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(get_sport_settings)
 mcp.tool(
     name="icu_update_sport_settings",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(update_sport_settings)
 mcp.tool(
     name="icu_apply_sport_settings",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(apply_sport_settings)
 mcp.tool(
     name="icu_create_sport_settings",
-    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
 )(create_sport_settings)
 mcp.tool(
     name="icu_delete_sport_settings",
-    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
 )(delete_sport_settings)
+
+# Register activity message tools
+mcp.tool(
+    name="icu_get_activity_messages",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(get_activity_messages)
+mcp.tool(
+    name="icu_add_activity_message",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)(add_activity_message)
+
+# Register custom item tools
+mcp.tool(
+    name="icu_get_custom_items",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(get_custom_items)
+mcp.tool(
+    name="icu_get_custom_item",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(get_custom_item)
+mcp.tool(
+    name="icu_create_custom_item",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)(create_custom_item)
+mcp.tool(
+    name="icu_update_custom_item",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(update_custom_item)
+mcp.tool(
+    name="icu_delete_custom_item",
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(delete_custom_item)
 
 
 # MCP Resources - Provide ongoing context

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -832,6 +832,7 @@ async def update_activity_streams(
                 )
             else:
                 import json
+
                 try:
                     streams = json.loads(payload_string)
                 except json.JSONDecodeError as e:
@@ -865,8 +866,8 @@ async def bulk_create_manual_activities(
 ) -> str:
     """Create multiple manual activities with upsert on external_id.
 
-    Existing activities with matching external_id, created by the same OAuth application 
-    are updated. Activities created/updated are returned. Activities with no external_id 
+    Existing activities with matching external_id, created by the same OAuth application
+    are updated. Activities created/updated are returned. Activities with no external_id
     are always created.
 
     Args:
@@ -878,8 +879,9 @@ async def bulk_create_manual_activities(
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
-    
+
     import json
+
     try:
         activities = json.loads(activities_json)
     except json.JSONDecodeError as e:
@@ -895,6 +897,7 @@ async def bulk_create_manual_activities(
         )
 
     from typing import Any
+
     activities_list: list[dict[str, Any]] = activities  # type: ignore[assignment]
 
     try:
@@ -917,7 +920,9 @@ async def bulk_create_manual_activities(
             return ResponseBuilder.build_response(
                 data={"activities": activities_data, "count": len(activities_data)},
                 query_type="bulk_create_manual_activities",
-                metadata={"message": f"Successfully processed {len(activities_data)} manual activities"},
+                metadata={
+                    "message": f"Successfully processed {len(activities_data)} manual activities"
+                },
             )
 
     except ICUAPIError as e:

--- a/src/intervals_icu_mcp/tools/activity_messages.py
+++ b/src/intervals_icu_mcp/tools/activity_messages.py
@@ -1,0 +1,119 @@
+"""Tools for notes, comments, and coach feedback attached to an activity.
+
+Intervals.icu calls these "messages" — they are the threaded comments that
+appear under an activity (the user's own training notes, comments from
+followers, or feedback from a coach). Use these tools when the user wants to
+read or post such notes/comments on a specific activity.
+"""
+
+from typing import Annotated, Any
+
+from fastmcp import Context
+
+from ..auth import ICUConfig
+from ..client import ICUAPIError, ICUClient
+from ..response_builder import ResponseBuilder
+
+
+def _message_to_dict(message: dict[str, Any]) -> dict[str, Any]:
+    """Extract a stable subset of message fields for tool responses."""
+    result: dict[str, Any] = {}
+    for key in ("id", "athlete_id", "name", "type", "content", "activity_id", "created", "seen"):
+        if key in message and message[key] is not None:
+            result[key] = message[key]
+    if message.get("attachment_url"):
+        result["attachment_url"] = message["attachment_url"]
+    return result
+
+
+async def get_activity_messages(
+    activity_id: Annotated[str, "The Intervals.icu activity ID"],
+    ctx: Context | None = None,
+) -> str:
+    """Read the notes and comments attached to a specific activity.
+
+    Use when the user asks: "what did my coach say about that ride?",
+    "show me the comments on yesterday's run", "read my notes on activity
+    X", "any feedback on this workout?". Returns every message on the
+    activity in chronological order, including the author name, content,
+    timestamp, and whether the user has seen it.
+
+    Args:
+        activity_id: The Intervals.icu activity ID (use icu_search_activities
+            or icu_get_recent_activities to find one if you only have a
+            description)
+
+    Returns:
+        JSON string with the list of messages and total count
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            messages = await client.get_activity_messages(activity_id)
+
+            return ResponseBuilder.build_response(
+                data={
+                    "activity_id": activity_id,
+                    "messages": [_message_to_dict(m) for m in messages],
+                },
+                metadata={"count": len(messages)},
+                query_type="activity_messages",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def add_activity_message(
+    activity_id: Annotated[str, "The Intervals.icu activity ID"],
+    content: Annotated[str, "Message content (note or comment text)"],
+    ctx: Context | None = None,
+) -> str:
+    """Post a note or comment on a specific activity.
+
+    Use when the user wants to leave a note on one of their activities:
+    "add a note to this ride that I felt strong", "comment on yesterday's
+    run", "leave a training note saying...". The post is attributed to the
+    authenticated user. Use icu_get_activity_messages first if you need to
+    see existing comments before adding to the thread.
+
+    Args:
+        activity_id: The Intervals.icu activity ID (use icu_search_activities
+            or icu_get_recent_activities to find one)
+        content: The message text to post (cannot be empty)
+
+    Returns:
+        JSON string with the new message ID and confirmation
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    if not content.strip():
+        return ResponseBuilder.build_error_response(
+            "content must not be empty", error_type="validation_error"
+        )
+
+    try:
+        async with ICUClient(config) as client:
+            result = await client.add_activity_message(activity_id, content)
+
+            data: dict[str, Any] = {"activity_id": activity_id}
+            if "id" in result:
+                data["message_id"] = result["id"]
+
+            return ResponseBuilder.build_response(
+                data=data,
+                metadata={"message": f"Successfully added message to activity {activity_id}"},
+                query_type="add_activity_message",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )

--- a/src/intervals_icu_mcp/tools/custom_items.py
+++ b/src/intervals_icu_mcp/tools/custom_items.py
@@ -1,0 +1,358 @@
+"""Tools for the user's customizations on Intervals.icu.
+
+These cover everything a user has added to personalize their account:
+custom charts (fitness, trace, activity), custom data fields (on wellness,
+activities, intervals), custom power/HR/pace zone configurations, custom
+activity streams, and custom dashboard panels/maps/heatmaps. The API calls
+this collection "custom items".
+"""
+
+from typing import Annotated, Any
+
+from fastmcp import Context
+
+from ..auth import ICUConfig
+from ..client import ICUAPIError, ICUClient
+from ..response_builder import ResponseBuilder
+
+VALID_CUSTOM_ITEM_TYPES = {
+    "FITNESS_CHART",
+    "FITNESS_TABLE",
+    "TRACE_CHART",
+    "INPUT_FIELD",
+    "ACTIVITY_FIELD",
+    "INTERVAL_FIELD",
+    "ACTIVITY_STREAM",
+    "ACTIVITY_CHART",
+    "ACTIVITY_HISTOGRAM",
+    "ACTIVITY_HEATMAP",
+    "ACTIVITY_MAP",
+    "ACTIVITY_PANEL",
+    "ZONES",
+}
+
+VALID_VISIBILITY = {"PRIVATE", "FOLLOWERS", "PUBLIC"}
+
+
+def _custom_item_to_dict(item: dict[str, Any]) -> dict[str, Any]:
+    """Extract a stable subset of custom item fields for tool responses."""
+    result: dict[str, Any] = {}
+    for key in (
+        "id",
+        "athlete_id",
+        "type",
+        "visibility",
+        "name",
+        "description",
+        "usage_count",
+        "index",
+        "updated",
+    ):
+        if key in item and item[key] is not None:
+            result[key] = item[key]
+    if item.get("content") is not None:
+        result["content"] = item["content"]
+    return result
+
+
+def _validate_type(item_type: str | None) -> str | None:
+    """Return an error message if item_type is invalid, or None if valid/absent."""
+    if item_type is None:
+        return None
+    if item_type not in VALID_CUSTOM_ITEM_TYPES:
+        valid = ", ".join(sorted(VALID_CUSTOM_ITEM_TYPES))
+        return f"Invalid item_type. Must be one of: {valid}"
+    return None
+
+
+def _validate_visibility(visibility: str | None) -> str | None:
+    """Return an error message if visibility is invalid, or None if valid/absent."""
+    if visibility is None:
+        return None
+    if visibility not in VALID_VISIBILITY:
+        return f"Invalid visibility. Must be one of: {', '.join(sorted(VALID_VISIBILITY))}"
+    return None
+
+
+async def get_custom_items(
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """List the user's custom additions to their Intervals.icu account.
+
+    Use this when the user asks about THEIR OWN customizations: "show my
+    custom charts", "list my custom fields", "what custom zones do I have",
+    "what's on my dashboard", "do I have any custom activity panels".
+
+    Returns every custom item across all types in one call: custom charts
+    (FITNESS_CHART, TRACE_CHART, ACTIVITY_CHART, ACTIVITY_HISTOGRAM,
+    ACTIVITY_HEATMAP, ACTIVITY_MAP, ACTIVITY_PANEL, FITNESS_TABLE), custom
+    data fields (INPUT_FIELD on wellness, ACTIVITY_FIELD on activities,
+    INTERVAL_FIELD on intervals), custom ACTIVITY_STREAM definitions, and
+    custom ZONES configurations. Each item has a `type` field so you can
+    filter client-side if the user asked about a specific kind.
+
+    Do NOT use this for built-in zones, built-in fields, or athlete profile
+    data — those have dedicated tools (icu_get_sport_settings, etc.).
+
+    Args:
+        athlete_id: Athlete ID (uses configured default if not provided)
+
+    Returns:
+        JSON string with the list of custom items and total count
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            items = await client.get_custom_items(athlete_id=athlete_id)
+
+            return ResponseBuilder.build_response(
+                data={"items": [_custom_item_to_dict(i) for i in items]},
+                metadata={"count": len(items)},
+                query_type="custom_items",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def get_custom_item(
+    item_id: Annotated[int, "Custom item ID"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Fetch the full configuration of one of the user's custom additions.
+
+    Use this AFTER icu_get_custom_items has returned an ID, when the user
+    wants to inspect a specific custom chart/field/zone/panel in detail
+    (the `content` field carries the full configuration which the list
+    endpoint also returns but is easier to focus on here).
+
+    Args:
+        item_id: Custom item ID (from icu_get_custom_items)
+        athlete_id: Athlete ID (uses configured default if not provided)
+
+    Returns:
+        JSON string with the custom item details including its `content` config
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            item = await client.get_custom_item(item_id, athlete_id=athlete_id)
+            return ResponseBuilder.build_response(
+                data=_custom_item_to_dict(item),
+                query_type="custom_item",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def create_custom_item(
+    name: Annotated[str, "Display name (e.g., 'RPE', 'Bike Weight', 'Custom Power Zones')"],
+    item_type: Annotated[
+        str,
+        "What the user wants to add. Pick by intent: "
+        "INPUT_FIELD (extra input on the wellness page, e.g. RPE, mood), "
+        "ACTIVITY_FIELD (extra field on each activity, e.g. bike weight), "
+        "INTERVAL_FIELD (extra field on each interval), "
+        "ZONES (custom power/HR/pace zone set), "
+        "FITNESS_CHART / TRACE_CHART / FITNESS_TABLE (custom dashboard "
+        "chart/table), "
+        "ACTIVITY_CHART / ACTIVITY_HISTOGRAM / ACTIVITY_HEATMAP / "
+        "ACTIVITY_MAP / ACTIVITY_PANEL (custom visual on the activity page), "
+        "ACTIVITY_STREAM (computed time-series). Use the literal API value.",
+    ],
+    description: Annotated[str | None, "Optional description shown to the user"] = None,
+    content: Annotated[
+        dict[str, Any] | None,
+        "Configuration object whose schema depends on item_type. For most "
+        "fields/charts you can omit this and configure later. Common gotchas: "
+        "for INPUT_FIELD/ACTIVITY_FIELD the inner 'type' must be 'numeric', "
+        "'text', or 'select' (NOT 'number'); 'aggregate' must be 'MIN', "
+        "'SUM', 'MAX', or 'AVERAGE' (NOT 'AVG').",
+    ] = None,
+    visibility: Annotated[
+        str | None,
+        "Who can see it: PRIVATE (default, only you), FOLLOWERS, or PUBLIC.",
+    ] = None,
+    athlete_id: Annotated[
+        str | None, "Athlete ID (only for coaches; uses configured default otherwise)"
+    ] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Create a custom addition to the user's Intervals.icu account.
+
+    Use when the user says things like: "add a custom field for RPE", "create
+    a custom power zone set", "add a chart for monthly distance to my
+    dashboard", "add a bike-weight field to activities". Match the user's
+    intent to the right `item_type` enum value (see that param's description
+    for the mapping).
+
+    Args:
+        name: Display name shown in the Intervals.icu UI
+        item_type: One of the API enum values matching the user's intent
+        description: Optional human-readable description
+        content: Optional configuration; schema varies by item_type
+        visibility: PRIVATE, FOLLOWERS, or PUBLIC
+        athlete_id: Athlete ID (uses configured default if not provided)
+
+    Returns:
+        JSON string with the created custom item including its new ID
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    type_error = _validate_type(item_type)
+    if type_error:
+        return ResponseBuilder.build_error_response(type_error, error_type="validation_error")
+    visibility_error = _validate_visibility(visibility)
+    if visibility_error:
+        return ResponseBuilder.build_error_response(visibility_error, error_type="validation_error")
+
+    item_data: dict[str, Any] = {"name": name, "type": item_type}
+    if description is not None:
+        item_data["description"] = description
+    if content is not None:
+        item_data["content"] = content
+    if visibility is not None:
+        item_data["visibility"] = visibility
+
+    try:
+        async with ICUClient(config) as client:
+            created = await client.create_custom_item(item_data, athlete_id=athlete_id)
+            return ResponseBuilder.build_response(
+                data=_custom_item_to_dict(created),
+                metadata={"message": f"Successfully created custom item: {name}"},
+                query_type="create_custom_item",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def update_custom_item(
+    item_id: Annotated[int, "Custom item ID to update"],
+    name: Annotated[str | None, "Updated name"] = None,
+    item_type: Annotated[str | None, "Updated type (see create_custom_item for values)"] = None,
+    description: Annotated[str | None, "Updated description"] = None,
+    content: Annotated[
+        dict[str, Any] | None, "Updated configuration content (replaces existing content)"
+    ] = None,
+    visibility: Annotated[str | None, "Updated visibility: PRIVATE, FOLLOWERS, or PUBLIC"] = None,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Modify an existing custom chart/field/zones/panel.
+
+    Use when the user wants to change one of their existing customizations:
+    "rename my custom field", "make this chart public", "change the
+    description on my zones". You usually need icu_get_custom_items first to
+    find the right `item_id`. Only fields you pass are sent — others are
+    left unchanged.
+
+    Args:
+        item_id: Custom item ID (from icu_get_custom_items)
+        name: New display name (optional)
+        item_type: New API type (optional, rare)
+        description: New description (optional)
+        content: New configuration object — REPLACES the existing one (optional)
+        visibility: New visibility: PRIVATE, FOLLOWERS, or PUBLIC (optional)
+        athlete_id: Athlete ID (uses configured default if not provided)
+
+    Returns:
+        JSON string with the updated custom item
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    type_error = _validate_type(item_type)
+    if type_error:
+        return ResponseBuilder.build_error_response(type_error, error_type="validation_error")
+    visibility_error = _validate_visibility(visibility)
+    if visibility_error:
+        return ResponseBuilder.build_error_response(visibility_error, error_type="validation_error")
+
+    item_data: dict[str, Any] = {}
+    if name is not None:
+        item_data["name"] = name
+    if item_type is not None:
+        item_data["type"] = item_type
+    if description is not None:
+        item_data["description"] = description
+    if content is not None:
+        item_data["content"] = content
+    if visibility is not None:
+        item_data["visibility"] = visibility
+
+    if not item_data:
+        return ResponseBuilder.build_error_response(
+            "No fields provided to update", error_type="validation_error"
+        )
+
+    try:
+        async with ICUClient(config) as client:
+            updated = await client.update_custom_item(item_id, item_data, athlete_id=athlete_id)
+            return ResponseBuilder.build_response(
+                data=_custom_item_to_dict(updated),
+                metadata={"message": f"Successfully updated custom item {item_id}"},
+                query_type="update_custom_item",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def delete_custom_item(
+    item_id: Annotated[int, "Custom item ID to delete"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Permanently remove one of the user's custom additions.
+
+    Use when the user says "delete my custom field for X", "remove that
+    chart from my dashboard", "drop the custom zones I made last week".
+    You usually need icu_get_custom_items first to find the right `item_id`.
+    This is destructive and cannot be undone — confirm with the user before
+    calling if you are unsure.
+
+    Args:
+        item_id: Custom item ID (from icu_get_custom_items)
+        athlete_id: Athlete ID (uses configured default if not provided)
+
+    Returns:
+        JSON string confirming deletion
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            await client.delete_custom_item(item_id, athlete_id=athlete_id)
+            return ResponseBuilder.build_response(
+                data={"item_id": item_id, "deleted": True},
+                metadata={"message": f"Successfully deleted custom item {item_id}"},
+                query_type="delete_custom_item",
+            )
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )

--- a/src/intervals_icu_mcp/tools/custom_items.py
+++ b/src/intervals_icu_mcp/tools/custom_items.py
@@ -176,11 +176,16 @@ async def create_custom_item(
     description: Annotated[str | None, "Optional description shown to the user"] = None,
     content: Annotated[
         dict[str, Any] | None,
-        "Configuration object whose schema depends on item_type. For most "
-        "fields/charts you can omit this and configure later. Common gotchas: "
-        "for INPUT_FIELD/ACTIVITY_FIELD the inner 'type' must be 'numeric', "
-        "'text', or 'select' (NOT 'number'); 'aggregate' must be 'MIN', "
-        "'SUM', 'MAX', or 'AVERAGE' (NOT 'AVG').",
+        "Configuration object whose schema depends on item_type. "
+        "REQUIRED for INPUT_FIELD, ACTIVITY_FIELD, INTERVAL_FIELD; for these "
+        "the schema is: `code` (machine identifier — must match regex "
+        "[A-Z][A-Za-z0-9]+, i.e. start with uppercase and contain only "
+        "alphanumerics, no spaces/underscores), `type` ('numeric', 'text', "
+        "or 'select' — NOT 'number'), `aggregate` ('MIN', 'SUM', 'MAX', or "
+        "'AVERAGE' — NOT 'AVG'). Example: "
+        "{'code': 'Rpe', 'type': 'numeric', 'aggregate': 'AVERAGE'}. "
+        "Optional for chart/panel/zones/stream types where the API uses "
+        "defaults — you can omit and configure in the Intervals.icu UI later.",
     ] = None,
     visibility: Annotated[
         str | None,
@@ -203,7 +208,10 @@ async def create_custom_item(
         name: Display name shown in the Intervals.icu UI
         item_type: One of the API enum values matching the user's intent
         description: Optional human-readable description
-        content: Optional configuration; schema varies by item_type
+        content: Configuration object. REQUIRED for INPUT_FIELD, ACTIVITY_FIELD,
+            INTERVAL_FIELD — see the parameter's annotation for the inner schema
+            (`code`, `type`, `aggregate`) and validation rules. Optional for
+            chart/panel/zones/stream types.
         visibility: PRIVATE, FOLLOWERS, or PUBLIC
         athlete_id: Athlete ID (uses configured default if not provided)
 
@@ -250,7 +258,12 @@ async def update_custom_item(
     item_type: Annotated[str | None, "Updated type (see create_custom_item for values)"] = None,
     description: Annotated[str | None, "Updated description"] = None,
     content: Annotated[
-        dict[str, Any] | None, "Updated configuration content (replaces existing content)"
+        dict[str, Any] | None,
+        "Updated configuration content (replaces existing content). Same "
+        "schema rules as create_custom_item.content — for field-type items "
+        "the inner shape is {`code`, `type`, `aggregate`} with the same "
+        "validation constraints (code regex [A-Z][A-Za-z0-9]+, type in "
+        "numeric/text/select, aggregate in MIN/SUM/MAX/AVERAGE).",
     ] = None,
     visibility: Annotated[str | None, "Updated visibility: PRIVATE, FOLLOWERS, or PUBLIC"] = None,
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -131,9 +131,7 @@ async def create_event(
         "HOLIDAY blocks so the planner skips or scales workouts.",
     ] = None,
     color: Annotated[str | None, "Custom display color (hex string)"] = None,
-    show_as_note: Annotated[
-        bool | None, "Show event as a note marker on the fitness chart"
-    ] = None,
+    show_as_note: Annotated[bool | None, "Show event as a note marker on the fitness chart"] = None,
     not_on_fitness_chart: Annotated[
         bool | None, "Hide event entirely from the fitness chart"
     ] = None,
@@ -254,9 +252,7 @@ async def create_event(
             return ResponseBuilder.build_response(
                 data=_event_to_dict(event),
                 query_type="create_event",
-                metadata={
-                    "message": f"Successfully created {normalized_category.lower()}: {name}"
-                },
+                metadata={"message": f"Successfully created {normalized_category.lower()}: {name}"},
             )
 
     except ICUAPIError as e:
@@ -738,7 +734,7 @@ async def apply_training_plan(
 ) -> str:
     """Apply a training plan.
 
-    Programmatically applies an entire training plan (workout folders/schedules) 
+    Programmatically applies an entire training plan (workout folders/schedules)
     directly onto an athlete's calendar.
 
     Args:
@@ -765,6 +761,7 @@ async def apply_training_plan(
     extra_workouts: list[dict[str, Any]] | None = None
     if extra_workouts_json:
         import json
+
         try:
             extra_workouts = json.loads(extra_workouts_json)
             if not isinstance(extra_workouts, list):

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -126,9 +126,7 @@ async def get_calendar_events(
             note_count = sum(1 for e in events if e.category == "NOTE")
             target_count = sum(1 for e in events if e.category == "TARGET")
             block_count = sum(
-                1
-                for e in events
-                if e.category in ("INJURED", "SICK", "HOLIDAY", "SEASON_START")
+                1 for e in events if e.category in ("INJURED", "SICK", "HOLIDAY", "SEASON_START")
             )
 
             summary = {

--- a/tests/test_activity_messages_tools.py
+++ b/tests/test_activity_messages_tools.py
@@ -1,0 +1,100 @@
+"""Tests for activity message tools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.activity_messages import (
+    add_activity_message,
+    get_activity_messages,
+)
+
+
+class TestActivityMessageTools:
+    """Tests for activity message tools."""
+
+    async def test_get_activity_messages_success(self, mock_config, respx_mock):
+        """Test fetching messages for an activity."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/12345/messages").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": 1,
+                        "athlete_id": "i123456",
+                        "name": "Coach",
+                        "type": "TEXT",
+                        "content": "Great ride!",
+                        "activity_id": "12345",
+                        "created": "2026-04-20T10:00:00",
+                        "seen": True,
+                    }
+                ],
+            )
+        )
+
+        result = await get_activity_messages(activity_id="12345", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["activity_id"] == "12345"
+        assert len(response["data"]["messages"]) == 1
+        assert response["data"]["messages"][0]["id"] == 1
+        assert response["data"]["messages"][0]["content"] == "Great ride!"
+        assert response["metadata"]["count"] == 1
+
+    async def test_get_activity_messages_empty(self, mock_config, respx_mock):
+        """Empty message list returns count=0."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/12345/messages").mock(return_value=Response(200, json=[]))
+
+        result = await get_activity_messages(activity_id="12345", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["messages"] == []
+        assert response["metadata"]["count"] == 0
+
+    async def test_add_activity_message_success(self, mock_config, respx_mock):
+        """Test adding a message to an activity."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.post("/activity/12345/messages").mock(
+            return_value=Response(200, json={"id": 42})
+        )
+
+        result = await add_activity_message(
+            activity_id="12345", content="Felt strong today", ctx=mock_ctx
+        )
+        response = json.loads(result)
+
+        assert response["data"]["activity_id"] == "12345"
+        assert response["data"]["message_id"] == 42
+        assert "Successfully added message" in response["metadata"]["message"]
+
+    async def test_add_activity_message_empty_content_rejected(self, mock_config):
+        """Empty content is rejected without an HTTP call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await add_activity_message(activity_id="12345", content="   ", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+
+    async def test_get_activity_messages_api_error(self, mock_config, respx_mock):
+        """API errors are surfaced as error responses."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/99999/messages").mock(return_value=Response(404))
+
+        result = await get_activity_messages(activity_id="99999", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "api_error"

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -130,7 +130,9 @@ class TestActivityTools:
         respx_mock.post("/athlete/i123456/activities/manual/bulk").mock(
             return_value=Response(
                 200,
-                json=[{"id": "a123", "name": "Bulk Ride", "start_date_local": "2026-03-20T10:00:00"}],
+                json=[
+                    {"id": "a123", "name": "Bulk Ride", "start_date_local": "2026-03-20T10:00:00"}
+                ],
             )
         )
 

--- a/tests/test_custom_items_tools.py
+++ b/tests/test_custom_items_tools.py
@@ -1,0 +1,196 @@
+"""Tests for custom item tools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.custom_items import (
+    create_custom_item,
+    delete_custom_item,
+    get_custom_item,
+    get_custom_items,
+    update_custom_item,
+)
+
+
+class TestCustomItemTools:
+    """Tests for custom item tools."""
+
+    async def test_get_custom_items_success(self, mock_config, respx_mock):
+        """List custom items for the configured athlete."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/custom-item").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": 7,
+                        "athlete_id": "i123456",
+                        "type": "ZONES",
+                        "visibility": "PRIVATE",
+                        "name": "My Zones",
+                    }
+                ],
+            )
+        )
+
+        result = await get_custom_items(ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["metadata"]["count"] == 1
+        assert response["data"]["items"][0]["id"] == 7
+        assert response["data"]["items"][0]["type"] == "ZONES"
+
+    async def test_get_custom_items_with_athlete_override(self, mock_config, respx_mock):
+        """athlete_id parameter overrides config default."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i999999/custom-item").mock(return_value=Response(200, json=[]))
+
+        result = await get_custom_items(athlete_id="i999999", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["metadata"]["count"] == 0
+
+    async def test_get_custom_item_success(self, mock_config, respx_mock):
+        """Get a single custom item by ID."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/custom-item/42").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 42,
+                    "athlete_id": "i123456",
+                    "type": "ACTIVITY_FIELD",
+                    "name": "Bike Weight",
+                    "content": {"type": "numeric"},
+                },
+            )
+        )
+
+        result = await get_custom_item(item_id=42, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["id"] == 42
+        assert response["data"]["content"] == {"type": "numeric"}
+
+    async def test_create_custom_item_success(self, mock_config, respx_mock):
+        """Create a new custom item."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.post("/athlete/i123456/custom-item").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 100,
+                    "athlete_id": "i123456",
+                    "type": "INPUT_FIELD",
+                    "name": "RPE",
+                    "visibility": "PRIVATE",
+                },
+            )
+        )
+
+        result = await create_custom_item(
+            name="RPE",
+            item_type="INPUT_FIELD",
+            visibility="PRIVATE",
+            ctx=mock_ctx,
+        )
+        response = json.loads(result)
+
+        assert response["data"]["id"] == 100
+        assert response["data"]["name"] == "RPE"
+        assert "Successfully created" in response["metadata"]["message"]
+
+    async def test_create_custom_item_invalid_type(self, mock_config):
+        """Invalid item_type is rejected without an HTTP call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await create_custom_item(name="X", item_type="NOT_A_REAL_TYPE", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+        assert "Invalid item_type" in response["error"]["message"]
+
+    async def test_create_custom_item_invalid_visibility(self, mock_config):
+        """Invalid visibility is rejected without an HTTP call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await create_custom_item(
+            name="X", item_type="ZONES", visibility="SECRET", ctx=mock_ctx
+        )
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+        assert "Invalid visibility" in response["error"]["message"]
+
+    async def test_update_custom_item_success(self, mock_config, respx_mock):
+        """Update an existing custom item."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.put("/athlete/i123456/custom-item/42").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 42,
+                    "athlete_id": "i123456",
+                    "type": "ACTIVITY_FIELD",
+                    "name": "Renamed Field",
+                },
+            )
+        )
+
+        result = await update_custom_item(item_id=42, name="Renamed Field", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["id"] == 42
+        assert response["data"]["name"] == "Renamed Field"
+
+    async def test_update_custom_item_no_fields_rejected(self, mock_config):
+        """Update with no fields is rejected without an HTTP call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await update_custom_item(item_id=42, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+        assert "No fields" in response["error"]["message"]
+
+    async def test_delete_custom_item_success(self, mock_config, respx_mock):
+        """Delete a custom item."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.delete("/athlete/i123456/custom-item/42").mock(
+            return_value=Response(200, json={})
+        )
+
+        result = await delete_custom_item(item_id=42, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["item_id"] == 42
+        assert response["data"]["deleted"] is True
+
+    async def test_get_custom_items_api_error(self, mock_config, respx_mock):
+        """API errors surface as error responses."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/custom-item").mock(return_value=Response(401))
+
+        result = await get_custom_items(ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "api_error"

--- a/tests/test_event_tools.py
+++ b/tests/test_event_tools.py
@@ -340,9 +340,7 @@ class TestEventTools:
         assert "error" in response
         assert "end_date" in response["error"]["message"]
 
-    async def test_update_event_can_set_end_date_and_availability(
-        self, mock_config, respx_mock
-    ):
+    async def test_update_event_can_set_end_date_and_availability(self, mock_config, respx_mock):
         """Updating an injury block to extend its end_date and change availability."""
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -61,9 +61,7 @@ class TestSportSettingsTools:
 
     async def test_get_sport_settings_empty(self, patch_config, respx_mock):
         """Empty result returns a friendly message with count=0."""
-        respx_mock.get("/athlete/i123456/sport-settings").mock(
-            return_value=Response(200, json=[])
-        )
+        respx_mock.get("/athlete/i123456/sport-settings").mock(return_value=Response(200, json=[]))
 
         result = await get_sport_settings()
 
@@ -73,9 +71,7 @@ class TestSportSettingsTools:
 
     async def test_get_sport_settings_api_error(self, patch_config, respx_mock):
         """API errors are surfaced via ResponseBuilder.build_error_response."""
-        respx_mock.get("/athlete/i123456/sport-settings").mock(
-            return_value=Response(401, json={})
-        )
+        respx_mock.get("/athlete/i123456/sport-settings").mock(return_value=Response(401, json={}))
 
         result = await get_sport_settings()
 

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -30,16 +30,18 @@ class TestInMemoryTransport:
         async with Client(mcp) as client:
             assert client.is_connected()
 
-    async def test_all_51_tools_registered(self):
+    async def test_all_58_tools_registered(self):
         async with Client(mcp) as client:
             tools = await client.list_tools()
-            assert len(tools) == 51
+            assert len(tools) == 58
             names = {t.name for t in tools}
             # Spot-check tools from different modules / tiers
             assert "icu_get_recent_activities" in names
             assert "icu_get_athlete_profile" in names
             assert "icu_bulk_create_events" in names  # Tier 2 coverage addition
             assert "icu_duplicate_events" in names
+            assert "icu_get_activity_messages" in names  # Activity messages
+            assert "icu_get_custom_items" in names  # Custom items
             assert "icu_update_sport_settings" in names
 
     async def test_tools_use_icu_prefix(self):
@@ -187,5 +189,5 @@ class TestHTTPTransport:
                 tools_body = (await tools_resp.aread()).decode()
                 tools_payload = self._parse_sse_response(tools_body)
                 tool_names = {t["name"] for t in tools_payload["result"]["tools"]}
-                assert len(tool_names) == 51
+                assert len(tool_names) == 58
                 assert "icu_get_recent_activities" in tool_names


### PR DESCRIPTION
## Summary

Adds two new tool categories — closing real functionality gaps in our coverage of the Intervals.icu API.

**Activity Messages (2 tools)** — read and post the threaded notes/comments shown under an activity (training notes, follower comments, coach feedback). Wraps `GET/POST /activity/{id}/messages`.

- `icu_get_activity_messages` — read notes/coach feedback on a specific activity
- `icu_add_activity_message` — post a note/comment on a specific activity

**Custom Items (5 tools)** — full CRUD for the user's personal additions to their account: custom charts, custom data fields (on wellness / activities / intervals), custom power/HR/pace zone configurations, custom dashboard panels. Wraps `GET/POST/PUT/DELETE /athlete/{id}/custom-item[/{itemId}]`.

- `icu_get_custom_items` — list the user's custom additions
- `icu_get_custom_item` — fetch one by ID
- `icu_create_custom_item` — add a custom chart/field/zones/panel
- `icu_update_custom_item` — modify an existing custom addition
- `icu_delete_custom_item` — permanently remove

## Tool count

51 → 58. New categories surface in `README.md`, `CLAUDE.md`, and `docs/tools.md` tables.

## Implementation notes

- Follows the established pattern: tool functions in `tools/<category>.py`, async context-manager API client methods in `client.py`, structured `ResponseBuilder` output, registration in `server.py`.
- Tool descriptions are deliberately written for **LLM readability** — each docstring leads with concrete user prompts ("show me my custom charts", "add a note to this ride") rather than the abstract API noun, so Claude/etc. can pick the right tool from intent.
- No new Pydantic models — both endpoints return simple shapes that we extract via small `_to_dict` helpers; matches the comparable approach used elsewhere in the codebase.
- Validation on `create_custom_item` rejects unknown `item_type` and `visibility` enum values before hitting the API, returning `validation_error` responses.

## Test plan

- [x] 15 new tests pass (`tests/test_activity_messages_tools.py`, `tests/test_custom_items_tools.py`) covering happy paths, validation rejection, athlete_id override, API error surfacing
- [x] Existing 84 tests continue to pass (transport integration test updated for tool-count assertion 51 → 58)
- [x] `make can-release` is green (ruff + pyright + pytest, plus pyroma 10/10)
- [x] Manual smoke test against a live Intervals.icu account using the prompts in the comment below

## Files changed

- New: `src/intervals_icu_mcp/tools/activity_messages.py`, `src/intervals_icu_mcp/tools/custom_items.py`
- New: `tests/test_activity_messages_tools.py`, `tests/test_custom_items_tools.py`
- Modified: `src/intervals_icu_mcp/client.py` (7 new async methods)
- Modified: `src/intervals_icu_mcp/server.py` (imports + tool registrations)
- Modified: `src/intervals_icu_mcp/tools/{activities,event_management,events}.py` and `tests/test_{activity,event,sport_settings,transport_integration}_tools.py` (cosmetic ruff format from `make format` run)
- Modified: `CLAUDE.md`, `README.md`, `docs/tools.md` (tool count + new category descriptions)
