### PR TITLE
fix(ci): update mcp-publisher asset glob to current upstream name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           gh release download --repo modelcontextprotocol/registry \
-            --pattern '*linux_amd64.tar.gz'
-          tar xzf mcp-publisher_*_linux_amd64.tar.gz
+            --pattern 'mcp-publisher_linux_amd64.tar.gz'
+          tar xzf mcp-publisher_linux_amd64.tar.gz
           chmod +x mcp-publisher
 
       - name: Publish to MCP Registry


### PR DESCRIPTION
Closes #21

## Summary
- Upstream `modelcontextprotocol/registry` dropped the `<version>_` segment from release asset filenames; the asset is now `mcp-publisher_linux_amd64.tar.gz`. The old glob `mcp-publisher_*_linux_amd64.tar.gz` no longer matches, causing the `tar` step to fail.
- Updated the download pattern and `tar` filename to the current name, and added `set -euo pipefail` so future asset renames fail fast at the download step instead of cascading.

## Test plan
- [ ] Cut a tag and confirm the Publish Release workflow's `mcp-registry` job downloads, extracts, and runs `mcp-publisher` successfully.