### PR TITLE
fix(ci): derive package version for Docker build via wheel pre-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Compute package version
+        id: version
+        run: |
+          set -euo pipefail
+          uv build --wheel --out-dir /tmp/wheel
+          PKG_VERSION=$(ls /tmp/wheel/intervals_icu_mcp-*.whl | sed -E 's|.*/intervals_icu_mcp-([^-]+)-.*|\1|')
+          echo "pkg_version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved PKG_VERSION=$PKG_VERSION"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -54,6 +68,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            PKG_VERSION=${{ steps.version.outputs.pkg_version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ COPY --from=uv /uv /usr/local/bin/uv
 # Set working directory
 WORKDIR /app
 
+# Version is derived from git via hatch-vcs at build time, but the .git
+# directory is not in the Docker build context. The CI workflow builds a
+# wheel locally to compute the version and passes it through as a build-arg.
+ARG PKG_VERSION=0.0.0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=$PKG_VERSION
+
 # Copy dependency files and README (needed for package metadata)
 COPY pyproject.toml uv.lock* README.md ./
 


### PR DESCRIPTION
Closes #20

## Summary
- The Release workflow's Docker build was failing because `hatch-vcs` needs git history to derive the version, but `.git` is not in the Docker build context.
- Implements the issue's recommended Option A (build-arg) with one tweak: instead of using raw `git describe` (not PEP 440 compliant for non-tagged commits), the workflow runs `uv build --wheel` first and extracts the version from the resulting wheel filename. That guarantees the value passed via `--build-arg PKG_VERSION=...` is exactly what hatch-vcs would have produced.
- Dockerfile picks up the arg as `SETUPTOOLS_SCM_PRETEND_VERSION` (the unscoped form — the scoped `_FOR_INTERVALS_ICU_MCP` variant did not work in testing). Default `0.0.0+docker` keeps `make docker/build` working without arguments.

## Test plan
- [x] Local `docker build --build-arg PKG_VERSION=1.2.1.dev9+test .` succeeds; `importlib.metadata.version('intervals-icu-mcp')` reports `1.2.1.dev9+test`.
- [x] Local `docker build .` (no args) succeeds; version reports `0.0.0+docker`.
- [ ] Merge to main and confirm the Release workflow's `build-and-push` job completes and produces `ghcr.io/hhopke/intervals-icu-mcp:latest`.