### PR TITLE
feat(activities): detect Strava-restricted activities and surface exp…

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -94,6 +94,8 @@ class ActivitySummary(BaseModel):
     average_cadence: float | None = None
     icu_training_load: int | None = None
     icu_intensity: float | None = None
+    source: str | None = None
+    note: str | None = Field(default=None, alias="_note")
 
 
 class Activity(ActivitySummary):

--- a/src/intervals_icu_mcp/tools/_strava.py
+++ b/src/intervals_icu_mcp/tools/_strava.py
@@ -1,0 +1,67 @@
+"""Strava-source detection helpers.
+
+Activities synced from Strava come back from the Intervals.icu API as a near-empty
+stub due to Strava's November 2024 API policy: Intervals.icu cannot legally
+redistribute Strava-sourced data through their API. This module detects that case
+and produces a clear, actionable message so callers can surface it instead of
+letting an LLM hallucinate metrics from empty fields.
+"""
+
+from ..client import ICUAPIError, ICUClient
+from ..models import Activity
+
+STRAVA_LIMITATION_NOTE = (
+    "This activity was synced from Strava, which restricts redistribution of its "
+    "activity data through third-party APIs (Strava policy change, November 2024). "
+    "As a result, Intervals.icu cannot expose detailed metrics, streams, intervals, "
+    "or histograms for Strava-sourced activities through its API — even though the "
+    "activity may display correctly in the Intervals.icu web UI. "
+    "To make this data available, connect your device directly to Intervals.icu "
+    "(e.g. Garmin Connect, Wahoo, Zwift, COROS, Polar, or Suunto direct sync) "
+    "instead of routing it through Strava."
+)
+
+
+def strava_limitation_note(activity: Activity) -> str | None:
+    """Return a user-facing note when an activity is a Strava-restricted stub.
+
+    Returns None for non-Strava activities and for Strava activities that still
+    have metric data (so we don't false-positive on, e.g., a manually-edited
+    Strava activity that happens to have populated fields).
+    """
+    if activity.source != "STRAVA":
+        return None
+
+    # Stub Strava activities have no metric/distance/duration data.
+    has_metrics = any(
+        v is not None
+        for v in (
+            activity.distance,
+            activity.moving_time,
+            activity.elapsed_time,
+            activity.total_elevation_gain,
+            activity.average_watts,
+            activity.normalized_power,
+            activity.average_heartrate,
+            activity.max_heartrate,
+            activity.average_cadence,
+            activity.average_speed,
+        )
+    )
+    if has_metrics:
+        return None
+    return STRAVA_LIMITATION_NOTE
+
+
+async def fetch_strava_limitation_note(client: ICUClient, activity_id: str) -> str | None:
+    """Fetch the activity and check whether it is Strava-restricted.
+
+    Used by tools (streams, intervals, histograms, best efforts) that don't
+    otherwise need the Activity object — only call this on the empty-result
+    path so we don't add latency for normal activities.
+    """
+    try:
+        activity = await client.get_activity(activity_id=activity_id)
+    except ICUAPIError:
+        return None
+    return strava_limitation_note(activity)

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from ._strava import strava_limitation_note
 
 
 async def get_recent_activities(
@@ -218,8 +219,14 @@ async def get_activity_details(
             if other_info:
                 activity_data["other"] = other_info
 
+            analysis: dict[str, Any] = {}
+            strava_note = strava_limitation_note(activity)
+            if strava_note:
+                analysis["data_availability"] = strava_note
+
             return ResponseBuilder.build_response(
                 data=activity_data,
+                analysis=analysis if analysis else None,
                 query_type="activity_details",
             )
 

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from ._strava import fetch_strava_limitation_note
 
 
 async def get_activity_streams(
@@ -51,8 +52,13 @@ async def get_activity_streams(
             stream_list = await client.get_activity_streams(activity_id, streams)
 
             if not stream_list:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"streams": {}, "available_streams": []},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No stream data available for this activity"},
                 )
 
@@ -114,8 +120,13 @@ async def get_activity_intervals(
             intervals = await client.get_activity_intervals(activity_id)
 
             if not intervals:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"intervals": [], "count": 0, "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No intervals found for this activity"},
                 )
 
@@ -248,8 +259,13 @@ async def get_best_efforts(
             )
 
             if not best_efforts.efforts:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"best_efforts": [], "count": 0, "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No best efforts found for this activity"},
                 )
 
@@ -385,8 +401,13 @@ async def get_power_histogram(
             histogram = await client.get_power_histogram(activity_id)
 
             if not histogram.bins:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"histogram": [], "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No power histogram data available for this activity"},
                 )
 
@@ -445,8 +466,13 @@ async def get_hr_histogram(
             histogram = await client.get_hr_histogram(activity_id)
 
             if not histogram.bins:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"histogram": [], "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No HR histogram data available for this activity"},
                 )
 
@@ -505,8 +531,13 @@ async def get_pace_histogram(
             histogram = await client.get_pace_histogram(activity_id)
 
             if not histogram.bins:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"histogram": [], "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No pace histogram data available for this activity"},
                 )
 
@@ -576,8 +607,13 @@ async def get_gap_histogram(
             histogram = await client.get_gap_histogram(activity_id)
 
             if not histogram.bins:
+                analysis: dict[str, Any] = {}
+                strava_note = await fetch_strava_limitation_note(client, activity_id)
+                if strava_note:
+                    analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
                     data={"histogram": [], "activity_id": activity_id},
+                    analysis=analysis if analysis else None,
                     metadata={"message": "No GAP histogram data available for this activity"},
                 )
 

--- a/tests/test_strava_limitation.py
+++ b/tests/test_strava_limitation.py
@@ -1,0 +1,230 @@
+"""Tests for Strava-restricted activity detection and messaging."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.models import Activity
+from intervals_icu_mcp.tools._strava import STRAVA_LIMITATION_NOTE, strava_limitation_note
+from intervals_icu_mcp.tools.activities import get_activity_details
+from intervals_icu_mcp.tools.activity_analysis import (
+    get_activity_intervals,
+    get_activity_streams,
+    get_best_efforts,
+    get_gap_histogram,
+    get_hr_histogram,
+    get_pace_histogram,
+    get_power_histogram,
+)
+
+STRAVA_STUB = {
+    "id": "16358453283",
+    "source": "STRAVA",
+    "_note": "STRAVA activities are not available via the API",
+    "start_date_local": "2025-11-04T19:21:15",
+}
+
+NON_STRAVA_EMPTY = {
+    "id": "12345",
+    "source": "MANUAL",
+    "start_date_local": "2025-11-04T19:21:15",
+}
+
+STRAVA_WITH_METRICS = {
+    "id": "999",
+    "source": "STRAVA",
+    "start_date_local": "2025-11-04T19:21:15",
+    "distance": 30000.0,
+    "moving_time": 3600,
+    "average_heartrate": 140,
+}
+
+
+class TestStravaLimitationHelper:
+    """Pure-function tests for strava_limitation_note."""
+
+    def test_detects_strava_stub(self):
+        activity = Activity.model_validate(STRAVA_STUB)
+        assert activity.source == "STRAVA"
+        assert activity.note == "STRAVA activities are not available via the API"
+        assert strava_limitation_note(activity) == STRAVA_LIMITATION_NOTE
+
+    def test_no_false_positive_on_non_strava_empty_activity(self):
+        activity = Activity.model_validate(NON_STRAVA_EMPTY)
+        assert strava_limitation_note(activity) is None
+
+    def test_no_false_positive_on_strava_with_metrics(self):
+        activity = Activity.model_validate(STRAVA_WITH_METRICS)
+        assert strava_limitation_note(activity) is None
+
+    def test_message_includes_workaround(self):
+        # Sanity-check the user-facing copy mentions the direct-sync workaround.
+        assert "directly to Intervals.icu" in STRAVA_LIMITATION_NOTE
+        assert "Garmin" in STRAVA_LIMITATION_NOTE
+
+
+class TestActivityDetailsStravaSurface:
+    """get_activity_details surfaces the limitation message in analysis."""
+
+    async def test_strava_stub_surfaces_message(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_activity_details(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert "analysis" in response
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_non_strava_no_message(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/12345").mock(
+            return_value=Response(200, json=NON_STRAVA_EMPTY)
+        )
+
+        result = await get_activity_details(activity_id="12345", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert "analysis" not in response
+
+
+class TestAnalysisToolsStravaSurface:
+    """Streams/intervals/best-efforts/histograms surface message on empty results."""
+
+    async def test_streams_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/streams.json").mock(
+            return_value=Response(200, json=[])
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_activity_streams(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_streams_non_strava_no_followup_call(self, mock_config, respx_mock):
+        """Empty streams on a non-Strava activity should not surface the message."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/12345/streams.json").mock(
+            return_value=Response(200, json=[])
+        )
+        respx_mock.get("/activity/12345").mock(
+            return_value=Response(200, json=NON_STRAVA_EMPTY)
+        )
+
+        result = await get_activity_streams(activity_id="12345", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert "analysis" not in response
+
+    async def test_intervals_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/intervals").mock(
+            return_value=Response(200, json={"id": "16358453283", "icu_intervals": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_activity_intervals(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_best_efforts_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/best-efforts").mock(
+            return_value=Response(200, json={"efforts": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_best_efforts(
+            activity_id="16358453283", duration=60, ctx=mock_ctx
+        )
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_power_histogram_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/power-histogram").mock(
+            return_value=Response(200, json={"bins": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_power_histogram(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_hr_histogram_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/hr-histogram").mock(
+            return_value=Response(200, json={"bins": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_hr_histogram(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_pace_histogram_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/pace-histogram").mock(
+            return_value=Response(200, json={"bins": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_pace_histogram(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE
+
+    async def test_gap_histogram_strava_stub(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/16358453283/gap-histogram").mock(
+            return_value=Response(200, json={"bins": []})
+        )
+        respx_mock.get("/activity/16358453283").mock(
+            return_value=Response(200, json=STRAVA_STUB)
+        )
+
+        result = await get_gap_histogram(activity_id="16358453283", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["analysis"]["data_availability"] == STRAVA_LIMITATION_NOTE


### PR DESCRIPTION
Closes #14.

## Summary
- Activities synced via Strava come back from the Intervals.icu API as a near-empty stub (Strava's Nov 2024 policy blocks redistribution). Today the server silently returns the sparse data and the LLM hallucinates "0 watts, no HR recorded…".
- Detect `source == "STRAVA"` + missing metrics and surface a clear message under `analysis.data_availability`, including the workaround (connect device directly: Garmin Connect, Wahoo, Zwift, COROS, Polar, Suunto).
- Wired into `get_activity_details`, `get_activity_streams`, `get_activity_intervals`, `get_best_efforts`, and the four histogram tools (power/HR/pace/GAP). Tools that don't already have the `Activity` only fetch it on the empty-result path, so normal activities pay no extra latency.

## Changes
- `models.py`: add `source` and `note` (alias `_note`) to `ActivitySummary`/`Activity`
- `tools/_strava.py`: new `strava_limitation_note(activity)` + async `fetch_strava_limitation_note(client, id)` helpers
- `tools/activities.py`, `tools/activity_analysis.py`: surface the message in `analysis.data_availability` on the empty-result path of the 8 affected tools
- `tests/test_strava_limitation.py`: 14 tests (helper + 8 tool integrations + false-positive guards)

## Test plan
- [x] `make can-release` passes locally (113 tests, ruff/pyright clean, packaging 10/10)
- [x] Helper unit tests: detects Strava stub, no false-positive on non-Strava empty activity, no false-positive on Strava activity with metrics
- [x] Integration tests across all 8 surfacing tools