### PR TITLE
fix(wellness): surface dropped API fields and label subjective scales

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -138,8 +138,24 @@ class ActivitySearchResult(BaseModel):
 # ==================== Wellness Models ====================
 
 
+class SportInfo(BaseModel):
+    """Per-sport context attached to a wellness record."""
+
+    type: str | None = None
+    eftp: float | None = None
+    w_prime: float | None = Field(None, alias="wPrime")
+    p_max: float | None = Field(None, alias="pMax")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class Wellness(BaseModel):
-    """Wellness record with health metrics."""
+    """Wellness record with health metrics.
+
+    `extra="allow"` lets us surface fields that the Intervals.icu API may add
+    in the future without losing them silently — every field the API returns
+    is preserved on the model, even if not enumerated here.
+    """
 
     id: str  # ISO-8601 date
     weight: float | None = None
@@ -156,17 +172,23 @@ class Wellness(BaseModel):
     mood: int | None = None
     motivation: int | None = None
     injury: int | None = None
-    spo2: float | None = None
+    spo2: float | None = Field(None, alias="spO2")
     respiration: float | None = None
     hydration: int | None = None
     hydration_volume: float | None = Field(None, alias="hydrationVolume")
     kcal_consumed: int | None = Field(None, alias="kcalConsumed")
+    carbohydrates: float | None = None
+    protein: float | None = None
+    fat_total: float | None = Field(None, alias="fatTotal")
     menstrual_phase: str | None = Field(None, alias="menstrualPhase")
+    menstrual_phase_predicted: str | None = Field(None, alias="menstrualPhasePredicted")
     systolic: int | None = None
     diastolic: int | None = None
     blood_glucose: float | None = Field(None, alias="bloodGlucose")
     lactate: float | None = None
     body_fat: float | None = Field(None, alias="bodyFat")
+    abdomen: float | None = None
+    vo2max: float | None = None
     readiness: float | None = None
     baevsky_si: float | None = Field(None, alias="baevskySI")
     steps: int | None = None
@@ -177,9 +199,13 @@ class Wellness(BaseModel):
     ctl_load: float | None = Field(None, alias="ctlLoad")
     atl_load: float | None = Field(None, alias="atlLoad")
     ramp_rate: float | None = Field(None, alias="rampRate")
+    sport_info: list[SportInfo] = Field(default_factory=list[SportInfo], alias="sportInfo")
+    locked: bool | None = None
+    temp_weight: bool | None = Field(None, alias="tempWeight")
+    temp_resting_hr: bool | None = Field(None, alias="tempRestingHR")
     updated: datetime | None = None
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
 
 # ==================== Event/Calendar Models ====================

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -353,6 +353,11 @@ async def update_wellness(
     mood: Annotated[int | None, "Mood level (1-5 scale)"] = None,
     motivation: Annotated[int | None, "Motivation level (1-5 scale)"] = None,
     readiness: Annotated[float | None, "Readiness score (0-100)"] = None,
+    calories_consumed: Annotated[int | None, "Calories consumed (kcal)"] = None,
+    carbohydrates: Annotated[float | None, "Carbohydrates consumed (grams)"] = None,
+    protein: Annotated[float | None, "Protein consumed (grams)"] = None,
+    fat_total: Annotated[float | None, "Total fat consumed (grams)"] = None,
+    hydration_liters: Annotated[float | None, "Hydration volume (liters)"] = None,
     comments: Annotated[str | None, "Comments or notes"] = None,
     ctx: Context | None = None,
 ) -> str:
@@ -377,6 +382,11 @@ async def update_wellness(
         mood: Mood rating (1-5)
         motivation: Motivation level (1-5)
         readiness: Overall readiness score (0-100)
+        calories_consumed: Total calories consumed in kcal
+        carbohydrates: Carbohydrates in grams
+        protein: Protein in grams
+        fat_total: Total fat in grams
+        hydration_liters: Hydration volume in liters
         comments: Any notes or comments about the day
 
     Returns:
@@ -420,6 +430,16 @@ async def update_wellness(
             wellness_data["motivation"] = motivation
         if readiness is not None:
             wellness_data["readiness"] = readiness
+        if calories_consumed is not None:
+            wellness_data["kcalConsumed"] = calories_consumed
+        if carbohydrates is not None:
+            wellness_data["carbohydrates"] = carbohydrates
+        if protein is not None:
+            wellness_data["protein"] = protein
+        if fat_total is not None:
+            wellness_data["fatTotal"] = fat_total
+        if hydration_liters is not None:
+            wellness_data["hydrationVolume"] = hydration_liters
         if comments is not None:
             wellness_data["comments"] = comments
 

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -9,6 +9,22 @@ from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
 
+# Scale labels for subjective metrics — surfaced in response metadata so LLM
+# clients that only see the JSON payload (not the tool docstring) can still
+# interpret the values correctly. Direction matters: sleep_quality is inverted
+# (1=Great, 5=Poor) while every other 1-5 metric is "higher = more".
+WELLNESS_SCALES: dict[str, str] = {
+    "fatigue": "1-5 (1=very low, 5=very high)",
+    "soreness": "1-5 (1=very low, 5=very high)",
+    "stress": "1-5 (1=very low, 5=very high)",
+    "mood": "1-5 (1=very poor, 5=very good)",
+    "motivation": "1-5 (1=very low, 5=very high)",
+    "injury": "1-5 (1=none, 5=severe)",
+    "sleep_quality": "1-5 (1=Great, 5=Poor — inverted scale)",
+    "sleep_score": "0-100 (device-specific, higher is better)",
+    "readiness": "0-100 (higher is better)",
+}
+
 
 def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
     """Format a wellness record object into a structured dictionary."""
@@ -56,6 +72,10 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
         body["weight_kg"] = record.weight
     if getattr(record, "body_fat", None):
         body["body_fat_percent"] = round(record.body_fat, 1)
+    if getattr(record, "abdomen", None):
+        body["abdomen_cm"] = round(record.abdomen, 1)
+    if getattr(record, "vo2max", None):
+        body["vo2max"] = round(record.vo2max, 1)
     if body:
         day_data["body"] = body
 
@@ -72,16 +92,27 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
     if vitals:
         day_data["vitals"] = vitals
 
-    # Activity & Nutrition
+    # Activity
     activity: dict[str, Any] = {}
     if getattr(record, "steps", None):
         activity["steps"] = record.steps
-    if getattr(record, "kcal_consumed", None):
-        activity["calories_consumed"] = record.kcal_consumed
-    if getattr(record, "hydration_volume", None):
-        activity["hydration_liters"] = round(record.hydration_volume, 1)
     if activity:
-        day_data["activity_nutrition"] = activity
+        day_data["activity"] = activity
+
+    # Nutrition
+    nutrition: dict[str, Any] = {}
+    if getattr(record, "kcal_consumed", None):
+        nutrition["calories_consumed"] = record.kcal_consumed
+    if getattr(record, "carbohydrates", None):
+        nutrition["carbohydrates_g"] = round(record.carbohydrates, 1)
+    if getattr(record, "protein", None):
+        nutrition["protein_g"] = round(record.protein, 1)
+    if getattr(record, "fat_total", None):
+        nutrition["fat_total_g"] = round(record.fat_total, 1)
+    if getattr(record, "hydration_volume", None):
+        nutrition["hydration_liters"] = round(record.hydration_volume, 1)
+    if nutrition:
+        day_data["nutrition"] = nutrition
 
     # Training load
     training: dict[str, Any] = {}
@@ -91,6 +122,33 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
     if training:
         day_data["training"] = training
 
+    # Per-sport context (eFTP, W', Pmax per sport type)
+    sport_info_raw: list[Any] = getattr(record, "sport_info", None) or []
+    sport_info_list: list[dict[str, Any]] = []
+    for sport in sport_info_raw:
+        entry: dict[str, Any] = {}
+        if getattr(sport, "type", None):
+            entry["type"] = sport.type
+        if getattr(sport, "eftp", None):
+            entry["eftp"] = round(sport.eftp, 1)
+        if getattr(sport, "w_prime", None):
+            entry["w_prime"] = round(sport.w_prime, 1)
+        if getattr(sport, "p_max", None):
+            entry["p_max"] = round(sport.p_max, 1)
+        if entry:
+            sport_info_list.append(entry)
+    if sport_info_list:
+        day_data["sport_info"] = sport_info_list
+
+    # State flags (record locked, fallback values in use)
+    state_flags: dict[str, Any] = {}
+    for field in ["locked", "temp_weight", "temp_resting_hr"]:
+        value = getattr(record, field, None)
+        if value is not None:
+            state_flags[field] = value
+    if state_flags:
+        day_data["state_flags"] = state_flags
+
     # Other metrics
     other: dict[str, Any] = {}
     if getattr(record, "blood_glucose", None):
@@ -99,6 +157,8 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
         other["lactate_mmol_per_l"] = round(record.lactate, 1)
     if getattr(record, "menstrual_phase", None):
         other["menstrual_phase"] = record.menstrual_phase
+    if getattr(record, "menstrual_phase_predicted", None):
+        other["menstrual_phase_predicted"] = record.menstrual_phase_predicted
     if other:
         day_data["other"] = other
 
@@ -107,6 +167,22 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
         day_data["comments"] = record.comments
 
     return day_data
+
+
+def _scales_for_records(records: list[dict[str, Any]]) -> dict[str, str]:
+    """Return scale labels only for subjective metrics actually present in output."""
+    present: set[str] = set()
+    for record in records:
+        sleep = record.get("sleep", {})
+        if "quality" in sleep:
+            present.add("sleep_quality")
+        if "score" in sleep:
+            present.add("sleep_score")
+        subjective = record.get("subjective", {})
+        for key in subjective:
+            if key in WELLNESS_SCALES:
+                present.add(key)
+    return {k: WELLNESS_SCALES[k] for k in present}
 
 
 async def get_wellness_data(
@@ -193,8 +269,14 @@ async def get_wellness_data(
             if trends:
                 result_data["trends"] = trends
 
+            metadata: dict[str, Any] = {}
+            scales = _scales_for_records(wellness_data)
+            if scales:
+                metadata["scales"] = scales
+
             return ResponseBuilder.build_response(
                 data=result_data,
+                metadata=metadata or None,
                 query_type="wellness_data",
             )
 
@@ -239,8 +321,14 @@ async def get_wellness_for_date(
 
             wellness_data = _format_wellness_record(wellness, date)
 
+            metadata: dict[str, Any] = {}
+            scales = _scales_for_records([wellness_data])
+            if scales:
+                metadata["scales"] = scales
+
             return ResponseBuilder.build_response(
                 data=wellness_data,
+                metadata=metadata or None,
                 query_type="wellness_for_date",
             )
 
@@ -346,10 +434,15 @@ async def update_wellness(
 
             result_data = _format_wellness_record(wellness, date)
 
+            metadata: dict[str, Any] = {"message": f"Successfully updated wellness for {date}"}
+            scales = _scales_for_records([result_data])
+            if scales:
+                metadata["scales"] = scales
+
             return ResponseBuilder.build_response(
                 data=result_data,
                 query_type="update_wellness",
-                metadata={"message": f"Successfully updated wellness for {date}"},
+                metadata=metadata,
             )
 
     except ICUAPIError as e:

--- a/tests/test_wellness_tools.py
+++ b/tests/test_wellness_tools.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 from httpx import Response
 
-from intervals_icu_mcp.tools.wellness import update_wellness
+from intervals_icu_mcp.tools.wellness import (
+    get_wellness_data,
+    get_wellness_for_date,
+    update_wellness,
+)
 
 
 class TestWellnessTools:
@@ -65,3 +69,131 @@ class TestWellnessTools:
         response = json.loads(result)
         assert "error" in response
         assert "No wellness data provided" in response["error"]["message"]
+
+    async def test_get_wellness_for_date_surfaces_new_fields(self, mock_config, respx_mock):
+        """Previously-dropped API fields and `spO2` alias must reach the output."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness/2026-04-20").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "2026-04-20",
+                    "weight": 71.0,
+                    "spO2": 97.5,
+                    "vo2max": 54.2,
+                    "abdomen": 82.4,
+                    "carbohydrates": 320.5,
+                    "protein": 140.2,
+                    "fatTotal": 70.1,
+                    "menstrualPhase": "FOLLICULAR",
+                    "menstrualPhasePredicted": "OVULATING",
+                    "locked": True,
+                    "tempWeight": False,
+                    "tempRestingHR": True,
+                    "sportInfo": [
+                        {"type": "Ride", "eftp": 252.3, "wPrime": 18000.0, "pMax": 1100.5},
+                    ],
+                },
+            )
+        )
+
+        result = await get_wellness_for_date(date="2026-04-20", ctx=mock_ctx)
+        response = json.loads(result)
+        data = response["data"]
+
+        assert data["body"]["vo2max"] == 54.2
+        assert data["body"]["abdomen_cm"] == 82.4
+        assert data["vitals"]["spo2_percent"] == 97.5
+        assert data["nutrition"]["carbohydrates_g"] == 320.5
+        assert data["nutrition"]["protein_g"] == 140.2
+        assert data["nutrition"]["fat_total_g"] == 70.1
+        assert data["other"]["menstrual_phase"] == "FOLLICULAR"
+        assert data["other"]["menstrual_phase_predicted"] == "OVULATING"
+        assert data["state_flags"] == {
+            "locked": True,
+            "temp_weight": False,
+            "temp_resting_hr": True,
+        }
+        assert data["sport_info"] == [
+            {"type": "Ride", "eftp": 252.3, "w_prime": 18000.0, "p_max": 1100.5}
+        ]
+
+    async def test_get_wellness_for_date_emits_scales(self, mock_config, respx_mock):
+        """Scale labels must appear in metadata for subjective metrics in output."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness/2026-04-20").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "2026-04-20",
+                    "fatigue": 4,
+                    "mood": 3,
+                    "sleepQuality": 2,
+                    "sleepScore": 82,
+                    "readiness": 75,
+                },
+            )
+        )
+
+        result = await get_wellness_for_date(date="2026-04-20", ctx=mock_ctx)
+        response = json.loads(result)
+
+        scales = response["metadata"]["scales"]
+        assert "fatigue" in scales and "1-5" in scales["fatigue"]
+        assert "mood" in scales
+        assert "sleep_quality" in scales and "inverted" in scales["sleep_quality"]
+        assert "sleep_score" in scales and "0-100" in scales["sleep_score"]
+        assert "readiness" in scales and "0-100" in scales["readiness"]
+        # Scales for fields not present should be absent
+        assert "soreness" not in scales
+        assert "stress" not in scales
+
+    async def test_get_wellness_data_includes_scales_and_extra_fields(
+        self, mock_config, respx_mock
+    ):
+        """List endpoint should also surface new fields and scale labels."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": "2026-04-20",
+                        "fatigue": 3,
+                        "carbohydrates": 250.0,
+                        "vo2max": 53.0,
+                    },
+                    {
+                        "id": "2026-04-19",
+                        "fatigue": 2,
+                        "protein": 130.0,
+                    },
+                ],
+            )
+        )
+
+        result = await get_wellness_data(days_back=2, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["count"] == 2
+        days = response["data"]["wellness_data"]
+        # Most recent first
+        assert days[0]["date"] == "2026-04-20"
+        assert days[0]["nutrition"]["carbohydrates_g"] == 250.0
+        assert days[0]["body"]["vo2max"] == 53.0
+        assert days[1]["nutrition"]["protein_g"] == 130.0
+        assert "fatigue" in response["metadata"]["scales"]
+
+    async def test_wellness_model_preserves_unknown_fields(self):
+        """`extra=allow` keeps future API additions accessible on the model."""
+        from intervals_icu_mcp.models import Wellness
+
+        record = Wellness.model_validate({"id": "2026-04-20", "weight": 70.0, "futureMetric": 42})
+        # Unknown field is preserved (not silently dropped)
+        assert getattr(record, "futureMetric", None) == 42


### PR DESCRIPTION
Closes #15.

## Summary
- `Wellness` model now uses `extra="allow"` so future API additions aren't silently dropped, and explicitly defines the 11 missing fields (`carbohydrates`, `protein`, `fatTotal`, `vo2max`, `abdomen`, `menstrualPhasePredicted`, `sportInfo`, `locked`, `tempWeight`, `tempRestingHR`) plus a `SportInfo` submodel. Also fixed a latent alias bug — `spo2` was never populating because the API returns `spO2`.
- Formatter surfaces the new fields in sensible sections: `nutrition` (split out from the old `activity_nutrition`), `body` gains `vo2max`/`abdomen_cm`, new `sport_info` and `state_flags` sections, and `menstrual_phase_predicted` joins `other`.
- Subjective metrics now ship with scale labels in `metadata.scales` (e.g. `"sleep_quality": "1-5 (1=Great, 5=Poor — inverted scale)"`). Only emitted for fields actually present in the response, so list queries stay compact. Chose metadata over inline labels to avoid duplicating scale text on every record.

## Test plan
- [x] `make can-release` passes (103 tests, ruff, pyright, pyroma 10/10)
- [x] New tests cover: new fields appear in output, `spO2` alias works, scale labels appear in metadata only for fields present, list endpoint surfaces both, `extra="allow"` preserves unknown fields
- [x] Spot-check against a real wellness record with nutrition macros set