### PR TITLE
feat: gate destructive tools behind INTERVALS_ICU_DELETE_MODE env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,44 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] — 2026-04-24
+## [Unreleased]
+
+This release will be cut as **2.0.0** — destructive-tool defaults change and `delete_event` response shape changes, both breaking per SemVer.
 
 ### Added
+- `INTERVALS_ICU_DELETE_MODE` env var (`safe` / `full` / `none`) gating which destructive tools are registered with the server. The gate sits outside the model's reach — unregistered tools cannot be invoked. See the README's *Delete Safety Mode* section.
+- Safe-mode partition logic: `delete_event` / `bulk_delete_events` skip past events (today and earlier) and return a uniform `deleted` / `skipped` envelope with reason codes.
+- Startup log line: `intervals-icu MCP starting: delete_mode=<mode>, registered_tools=<n>`.
+- Strava-restricted activity detection: activity and analysis tools surface an explanation when Strava data is unavailable due to privacy settings.
+- `update_wellness` now accepts nutrition macro fields (`calories`, `carbs`, `fat`, `protein`, `fiber`).
+
+### Fixed
+- Wellness tools: surfaced previously dropped API fields and added human-readable labels for subjective scales (sleep quality, readiness, mood, fatigue, etc.).
+
+### Changed
+- **Breaking — default behavior:** `delete_activity`, `delete_sport_settings`, `delete_custom_item` are no longer registered out of the box. Set `INTERVALS_ICU_DELETE_MODE=full` to restore them. Sport settings and custom items are gated because their deletion impacts historical chart math and stored activity data, respectively.
+- **Breaking — response shape:** `delete_event` returns the `deleted` / `skipped` envelope (was `{event_id, deleted: true}`).
+- Bumped FastMCP from 3.1.1 to 3.2.4.
+
+## [1.3.0] — 2026-04-26
+
+### Added
+- **Activity messages tools** — read and write notes/comments on activities via `icu_get_activity_messages` and `icu_add_activity_message`.
+- **Custom items tools** — full CRUD for custom charts, fields, zones, and dashboard items via `icu_get_custom_items`, `icu_get_custom_item`, `icu_create_custom_item`, `icu_update_custom_item`, `icu_delete_custom_item`. Includes documented content schema and conditional-required fields for field-type items.
+- ChatGPT connector setup documented in the README (HTTP transport + tunnel walkthrough).
+- Automated OpenAPI spec refresh via `.github/workflows/update-openapi.yml`; bot commits are GPG-signed to satisfy the verified-signature branch rule.
+
+### Fixed
+- Docker release build: package version is now derived from a pre-built wheel so `hatch-vcs` resolves correctly inside the build context.
+- MCP Registry publish: `mcp-publisher` asset glob updated to the current upstream artifact name.
+
+## [1.2.0] — 2026-04-25
+
+### Added
+- **Full calendar category support** — `create_event` / `update_event` / `bulk_create_events` accept the complete Intervals.icu category enum (RACE_A/B/C, TARGET, PLAN, HOLIDAY, SICK, INJURED, SET_EFTP, FITNESS_DAYS, SEASON_START, SET_FITNESS) plus range fields (`end_date_local`) and `training_availability` (NORMAL/LIMITED/UNAVAILABLE) for life-event blocks. Legacy `RACE`→`RACE_A` and `GOAL`→`TARGET` aliases accepted.
 - Automated MCP Registry publishing on release via GitHub OIDC — `server.json` version is synced from the release tag, no manual bump required.
+- PyPI package quality gates in CI: `twine check`, `pyroma --min=10`, and link verification.
+- Dynamic versioning via `hatch-vcs` — package version flows from the git tag, no manual edits in `pyproject.toml`.
 
 ### Changed
 - README trimmed; reference content extracted to [docs/examples.md](docs/examples.md) and [docs/tools.md](docs/tools.md) for clearer onboarding and discoverability.
@@ -23,15 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Expanded the HTTP transport security warning in the README with concrete deployment guidance (Tailscale, Cloudflare Tunnel, reverse-proxy-with-auth, SSH tunnel).
 
+## [1.0.2] — 2026-04-24
+
+### Fixed
+- LICENSE file now packaged with the PyPI distribution and links resolve correctly from the PyPI page.
+- `server.json` description shortened to meet the MCP Registry 100-char limit.
+
 ## [1.0.1] — 2026-04-24
 
 ### Added
 - PyPI publish workflow via Trusted Publishers.
 - MCP Registry submission metadata (`server.json`).
-
-### Fixed
-- LICENSE file now packaged with the PyPI distribution and links resolve correctly from the PyPI page.
-- `server.json` description shortened to meet the MCP Registry 100-char limit.
 
 ### Changed
 - Documentation leads with the `uvx` install flow now that the package is on PyPI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Intervals.icu — provides 58 tools, 2 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs.
+MCP (Model Context Protocol) server for Intervals.icu — provides up to 58 tools, 2 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 55 tools; `full` registers all 58, `none` registers 52.
 
 - **Language**: Python 3.11+
 - **Framework**: FastMCP
@@ -83,9 +83,14 @@ Tests use pytest + pytest-asyncio with `respx` for HTTP mocking.
 ## Further Documentation
 
 - `docs/architecture.md` — Detailed architecture and design decisions
-- `docs/tools.md` — Reference for all registered tools
+- `docs/tools.md` — Reference for all registered tools (and the Delete Safety Mode spec)
 - `docs/examples.md` — Usage examples
 - `docs/testing.md` — Testing conventions
+- `docs/chatgpt-connector.md` — ChatGPT custom-connector setup walkthrough
+
+### README discipline
+
+**Keep README.md under 300 lines.** It is the front door for new users — onboarding, install, basic config, links out. Reference material (full tool inventory, deep architectural notes, exhaustive examples) belongs in `docs/`, not the README. If a new section grows past ~30 lines and isn't core onboarding, extract it to `docs/` and link from the README. The README has been trimmed before (PR #6) — don't let it bloat back.
 
 ## Skills
 
@@ -100,6 +105,20 @@ The following skills are available in `.claude/skills/`:
 ## Verification
 
 **Always run `make can-release` before finishing any feature work.** This runs the full test and lint suite, matching what CI checks on every push.
+
+## Releases
+
+CHANGELOG.md is **manual** — there is no automated changelog generation. The only release-related automation:
+- Package version comes from the git tag via `hatch-vcs` (no `pyproject.toml` bump needed)
+- `publish.yml` syncs `server.json` version from the tag and publishes to PyPI + MCP Registry
+- `release.yml` builds and pushes the Docker image
+
+To cut a release:
+1. Rename `## [Unreleased]` → `## [X.Y.Z] — YYYY-MM-DD` in CHANGELOG.md
+2. Commit (e.g., `chore(release): X.Y.Z`)
+3. Tag and push: `git tag vX.Y.Z && git push origin main vX.Y.Z`
+
+Follow strict SemVer — breaking changes (response shape changes, default-behavior changes that remove tools, removed parameters) require a major bump. The CHANGELOG header explicitly commits to SemVer.
 
 ## Important Files
 

--- a/README.md
+++ b/README.md
@@ -191,48 +191,13 @@ Restart Cursor and open *Settings → MCP* to verify the server is listed.
 <details>
 <summary><b>ChatGPT</b> — requires a paid plan, Developer Mode, and a publicly reachable URL <em>(walkthrough not yet verified end-to-end)</em></summary>
 
-> ⚠️ **Unverified.** The steps below are derived from OpenAI's and FastMCP's docs but have not been confirmed end-to-end against this server. Plan-tier eligibility for custom MCP connectors changes frequently — always check OpenAI's [current connector docs](https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta) before assuming your plan supports it. PRs from anyone who has confirmed the flow are welcome.
-
-**Requirements (as of writing)**
-- A ChatGPT plan that supports custom MCP connectors and Developer Mode (typically a paid tier — Free does not qualify; check OpenAI docs for the current list).
-- **Developer Mode** enabled in ChatGPT settings.
-- A public HTTPS URL pointing at the server (a tunnel is the easiest way).
-
-**Step 1 — Start the server in HTTP mode**
-
-```bash
-intervals-icu-mcp --transport http --host 127.0.0.1 --port 8000
-```
-
-**Step 2 — Expose it via a tunnel**
-
-*Cloudflare Tunnel (free, recommended):*
-```bash
-brew install cloudflared   # macOS — or download from developers.cloudflare.com
-cloudflared tunnel --url http://127.0.0.1:8000
-```
-Cloudflare prints a URL like `https://abc-def-123.trycloudflare.com`. Your MCP endpoint is `https://abc-def-123.trycloudflare.com/mcp`.
-
-*ngrok (quick to try, URL changes on free-tier restart):*
-```bash
-ngrok http 8000
-```
-Your endpoint is `https://<random>.ngrok-free.app/mcp`.
-
-**Step 3 — Add the connector in ChatGPT**
-
-1. ChatGPT → **Settings** → **Connectors** → enable **Developer Mode** (Advanced settings) if you haven't already.
-2. **Connectors** → **Create** (or **Add new connector**).
-3. **MCP Server URL**: your tunnel URL with `/mcp` appended.
-4. **Authentication**: *No authentication* is fine for personal use behind a tunnel; configure OAuth if you've put one in front.
-5. Click **Create** and trust the provider.
-6. In each new chat, enable the connector from the chat's tools menu — it isn't enabled globally.
-
-**Security note:** The server runs with your personal `INTERVALS_ICU_API_KEY` — anyone who knows the tunnel URL can query your account. Add [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/) or [Tailscale Funnel](https://tailscale.com/kb/1223/tailscale-funnel) to restrict who can reach the endpoint.
-
-> Deep Research mode (a separate ChatGPT feature) requires `search` and `fetch` tools that this server doesn't expose, so it will reject the connector there. Regular chat with Developer Mode works.
+ChatGPT's custom MCP connector flow requires running the server over HTTP and exposing it via a tunnel, then registering the URL in ChatGPT's Developer Mode settings. See [docs/chatgpt-connector.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/chatgpt-connector.md) for the full walkthrough, plan-tier requirements, and security notes.
 
 </details>
+
+## Delete Safety Mode
+
+Destructive tools are gated by the optional `INTERVALS_ICU_DELETE_MODE` env var (`safe` / `full` / `none`, default `safe`). The gate is server-side and outside the model's reach — tools that aren't registered cannot be invoked. Safe mode refuses past-event deletion and gates `delete_activity` / `delete_sport_settings` / `delete_custom_item` entirely. See [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#delete-safety-mode) for the full table, response envelope, and TZ-buffer rationale.
 
 ## Remote Deployment (HTTP / SSE)
 

--- a/docs/chatgpt-connector.md
+++ b/docs/chatgpt-connector.md
@@ -1,0 +1,49 @@
+# ChatGPT Custom Connector Setup
+
+> ⚠️ **Unverified.** The steps below are derived from OpenAI's and FastMCP's docs but have not been confirmed end-to-end against this server. Plan-tier eligibility for custom MCP connectors changes frequently — always check OpenAI's [current connector docs](https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta) before assuming your plan supports it. PRs from anyone who has confirmed the flow are welcome.
+
+## Requirements (as of writing)
+
+- A ChatGPT plan that supports custom MCP connectors and Developer Mode (typically a paid tier — Free does not qualify; check OpenAI docs for the current list).
+- **Developer Mode** enabled in ChatGPT settings.
+- A public HTTPS URL pointing at the server (a tunnel is the easiest way).
+
+## Step 1 — Start the server in HTTP mode
+
+```bash
+intervals-icu-mcp --transport http --host 127.0.0.1 --port 8000
+```
+
+## Step 2 — Expose it via a tunnel
+
+**Cloudflare Tunnel (free, recommended):**
+
+```bash
+brew install cloudflared   # macOS — or download from developers.cloudflare.com
+cloudflared tunnel --url http://127.0.0.1:8000
+```
+
+Cloudflare prints a URL like `https://abc-def-123.trycloudflare.com`. Your MCP endpoint is `https://abc-def-123.trycloudflare.com/mcp`.
+
+**ngrok (quick to try, URL changes on free-tier restart):**
+
+```bash
+ngrok http 8000
+```
+
+Your endpoint is `https://<random>.ngrok-free.app/mcp`.
+
+## Step 3 — Add the connector in ChatGPT
+
+1. ChatGPT → **Settings** → **Connectors** → enable **Developer Mode** (Advanced settings) if you haven't already.
+2. **Connectors** → **Create** (or **Add new connector**).
+3. **MCP Server URL**: your tunnel URL with `/mcp` appended.
+4. **Authentication**: *No authentication* is fine for personal use behind a tunnel; configure OAuth if you've put one in front.
+5. Click **Create** and trust the provider.
+6. In each new chat, enable the connector from the chat's tools menu — it isn't enabled globally.
+
+## Security note
+
+The server runs with your personal `INTERVALS_ICU_API_KEY` — anyone who knows the tunnel URL can query your account. Add [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/) or [Tailscale Funnel](https://tailscale.com/kb/1223/tailscale-funnel) to restrict who can reach the endpoint.
+
+> Deep Research mode (a separate ChatGPT feature) requires `search` and `fetch` tools that this server doesn't expose, so it will reject the connector there. Regular chat with Developer Mode works.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,48 @@
 # Tool, Resource, and Prompt Reference
 
-Complete inventory of everything the Intervals.icu MCP server exposes: 58 tools across 11 categories, 2 MCP Resources, and 7 MCP Prompts.
+Complete inventory of everything the Intervals.icu MCP server exposes: up to 58 tools across 11 categories, 2 MCP Resources, and 7 MCP Prompts.
+
+## Delete Safety Mode
+
+Destructive tools are gated by the optional `INTERVALS_ICU_DELETE_MODE` env var. The gate sits **outside the model's reach** — tools that aren't registered cannot be invoked by any prompt or parameter.
+
+| Mode | Registered tools | Events | Activities | Gear | Sport settings | Custom items |
+|---|---|---|---|---|---|---|
+| `safe` (default) | 55 | tomorrow or later | ✗ | ✓ | ✗ | ✗ |
+| `full` | 58 | any date | ✓ | ✓ | ✓ | ✓ |
+| `none` | 52 | ✗ | ✗ | ✗ | ✗ | ✗ |
+
+In `safe` mode, `icu_delete_event` and `icu_bulk_delete_events` return a uniform envelope showing what was deleted and what was skipped:
+
+```json
+{
+  "deleted": [124],
+  "deleted_count": 1,
+  "skipped": [
+    {
+      "id": 123,
+      "reason": "past_event",
+      "start_date_local": "2026-04-15",
+      "hint": "Past events (today and earlier) require INTERVALS_ICU_DELETE_MODE=full."
+    }
+  ],
+  "skipped_count": 1
+}
+```
+
+Set the mode in your client config alongside the credentials:
+
+```json
+"env": {
+  "INTERVALS_ICU_API_KEY": "your-api-key-here",
+  "INTERVALS_ICU_ATHLETE_ID": "i123456",
+  "INTERVALS_ICU_DELETE_MODE": "safe"
+}
+```
+
+**Why today is treated as past:** Safe mode only deletes events dated *strictly after today* in the server's local timezone. The one-day buffer absorbs server-vs-athlete TZ skew. If you run the server in Docker (defaults to UTC) and live in a different timezone, set the container's `TZ` env var to match your athlete profile (e.g., `TZ=Europe/Berlin`) so "today" lines up.
+
+**Why sport settings and custom items are full-only:** Sport-settings deletion shifts retroactive chart math (current FTP/zones drive past activity calculations on Intervals.icu, so deleting them re-renders historical training load). Custom items can be data-bearing fields whose values are stored across activities. Neither is recoverable by re-creating the deleted record.
 
 ## Tools
 
@@ -14,7 +56,7 @@ Complete inventory of everything the Intervals.icu MCP server exposes: 58 tools 
 | `icu_search_activities_full` | Search activities with full details               |
 | `icu_get_activities_around`  | Get activities before and after a specific one    |
 | `icu_update_activity`        | Update activity name, description, or metadata    |
-| `icu_delete_activity`        | Delete an activity                                |
+| `icu_delete_activity`        | Delete an activity *(only registered when `INTERVALS_ICU_DELETE_MODE=full`)* |
 | `icu_download_activity_file` | Download original activity file                   |
 | `icu_download_fit_file`      | Download activity as FIT file                     |
 | `icu_download_gpx_file`      | Download activity as GPX file                     |
@@ -67,9 +109,9 @@ The threaded notes/comments shown under an activity — the user's own training 
 | `icu_get_event`             | Get details for a specific event                           |
 | `icu_create_event`          | Create new calendar events (workouts, races, notes, goals) |
 | `icu_update_event`          | Modify existing calendar events                            |
-| `icu_delete_event`          | Remove events from calendar                                |
+| `icu_delete_event`          | Remove an event from the calendar *(safe mode: future events only; envelope returns `deleted` / `skipped`)* |
 | `icu_bulk_create_events`    | Create multiple events in a single operation               |
-| `icu_bulk_delete_events`    | Delete multiple events in a single operation               |
+| `icu_bulk_delete_events`    | Delete multiple events in a single operation *(safe mode partitions into `deleted` / `skipped`)* |
 | `icu_duplicate_events`      | Duplicate one or more events with configurable copies and spacing |
 | `icu_apply_training_plan` | Apply an entire training plan (workout folder) onto the calendar |
 
@@ -107,7 +149,7 @@ The threaded notes/comments shown under an activity — the user's own training 
 | `icu_update_sport_settings` | Update FTP, FTHR, pace threshold, or zone configuration |
 | `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
 | `icu_create_sport_settings` | Create new sport-specific settings                      |
-| `icu_delete_sport_settings` | Delete sport-specific settings                          |
+| `icu_delete_sport_settings` | Delete sport-specific settings *(only registered when `INTERVALS_ICU_DELETE_MODE=full`; deletion shifts retroactive chart math)* |
 
 ### Custom Items (5 tools)
 
@@ -119,7 +161,7 @@ The user's personal additions to their account: custom charts on dashboards, cus
 | `icu_get_custom_item`       | Fetch the full configuration of one custom addition by ID                  |
 | `icu_create_custom_item`    | Add a new custom chart, field, zones config, or dashboard panel            |
 | `icu_update_custom_item`    | Modify an existing custom addition (rename, reconfigure, change visibility)|
-| `icu_delete_custom_item`    | Permanently remove a custom addition                                       |
+| `icu_delete_custom_item`    | Permanently remove a custom addition *(only registered when `INTERVALS_ICU_DELETE_MODE=full`; data-bearing field types may cascade)* |
 
 ## MCP Resources
 

--- a/src/intervals_icu_mcp/auth.py
+++ b/src/intervals_icu_mcp/auth.py
@@ -2,9 +2,14 @@
 
 import os
 from pathlib import Path
+from typing import Literal
 
 from dotenv import load_dotenv, set_key
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DeleteMode = Literal["safe", "full", "none"]
+VALID_DELETE_MODES: tuple[DeleteMode, ...] = ("safe", "full", "none")
 
 
 class ICUConfig(BaseSettings):
@@ -18,6 +23,20 @@ class ICUConfig(BaseSettings):
 
     intervals_icu_api_key: str = ""
     intervals_icu_athlete_id: str = ""
+    intervals_icu_delete_mode: DeleteMode = "safe"
+
+    @field_validator("intervals_icu_delete_mode", mode="before")
+    @classmethod
+    def _normalize_delete_mode(cls, v: object) -> str:
+        if v is None or v == "":
+            return "safe"
+        normalized = str(v).lower().strip()
+        if normalized not in VALID_DELETE_MODES:
+            raise ValueError(
+                "INTERVALS_ICU_DELETE_MODE must be one of: "
+                f"{', '.join(VALID_DELETE_MODES)}. Got: '{v}'"
+            )
+        return normalized
 
 
 def load_config() -> ICUConfig:

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -1,6 +1,7 @@
 """Intervals.icu MCP Server - FastMCP entry point."""
 
 import argparse
+import sys
 from typing import Any
 
 from dotenv import load_dotenv
@@ -13,9 +14,15 @@ load_dotenv()
 mcp = FastMCP("intervals_icu_mcp")
 
 # Register middleware
+from .auth import load_config
 from .middleware import ConfigMiddleware
 
 mcp.add_middleware(ConfigMiddleware())
+
+# Read delete mode at startup. This decides which destructive tools are
+# *registered* with the server — the safety floor sits outside the LLM's reach
+# (no parameter the model invents can summon a tool that wasn't registered).
+_DELETE_MODE = load_config().intervals_icu_delete_mode
 
 # Import and register tools
 from .tools.activities import (
@@ -154,15 +161,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(bulk_create_manual_activities)
-mcp.tool(
-    name="icu_delete_activity",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(delete_activity)
+if _DELETE_MODE == "full":
+    mcp.tool(
+        name="icu_delete_activity",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(delete_activity)
 mcp.tool(
     name="icu_download_activity_file",
     annotations={
@@ -360,15 +368,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(update_event)
-mcp.tool(
-    name="icu_delete_event",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(delete_event)
+if _DELETE_MODE in ("safe", "full"):
+    mcp.tool(
+        name="icu_delete_event",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(delete_event)
 mcp.tool(
     name="icu_bulk_create_events",
     annotations={
@@ -378,15 +387,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(bulk_create_events)
-mcp.tool(
-    name="icu_bulk_delete_events",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(bulk_delete_events)
+if _DELETE_MODE in ("safe", "full"):
+    mcp.tool(
+        name="icu_bulk_delete_events",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(bulk_delete_events)
 mcp.tool(
     name="icu_duplicate_events",
     annotations={
@@ -483,15 +493,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(update_gear)
-mcp.tool(
-    name="icu_delete_gear",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(delete_gear)
+if _DELETE_MODE in ("safe", "full"):
+    mcp.tool(
+        name="icu_delete_gear",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(delete_gear)
 mcp.tool(
     name="icu_create_gear_reminder",
     annotations={
@@ -548,15 +559,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(create_sport_settings)
-mcp.tool(
-    name="icu_delete_sport_settings",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(delete_sport_settings)
+if _DELETE_MODE == "full":
+    mcp.tool(
+        name="icu_delete_sport_settings",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(delete_sport_settings)
 
 # Register activity message tools
 mcp.tool(
@@ -615,15 +627,16 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(update_custom_item)
-mcp.tool(
-    name="icu_delete_custom_item",
-    annotations={
-        "readOnlyHint": False,
-        "destructiveHint": True,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
-)(delete_custom_item)
+if _DELETE_MODE == "full":
+    mcp.tool(
+        name="icu_delete_custom_item",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    )(delete_custom_item)
 
 
 # MCP Resources - Provide ongoing context
@@ -1006,9 +1019,27 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+async def _count_registered_tools() -> int:
+    return len(await mcp.list_tools())
+
+
+def _emit_startup_log() -> None:
+    import asyncio
+
+    try:
+        count = asyncio.run(_count_registered_tools())
+    except Exception:
+        count = -1
+    print(
+        f"intervals-icu MCP starting: delete_mode={_DELETE_MODE}, registered_tools={count}",
+        file=sys.stderr,
+    )
+
+
 def main() -> None:
     """Main entry point for the Intervals.icu MCP server."""
     args = _parse_args()
+    _emit_startup_log()
 
     if args.transport == "stdio":
         mcp.run()

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -1,6 +1,7 @@
 """Event/calendar management tools for Intervals.icu MCP server."""
 
-from datetime import datetime
+import asyncio
+from datetime import date, datetime
 from typing import Annotated, Any, cast
 
 from fastmcp import Context
@@ -9,6 +10,67 @@ from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..models import Event
 from ..response_builder import ResponseBuilder
+
+PAST_EVENT_HINT = (
+    "Past events (today and earlier) require INTERVALS_ICU_DELETE_MODE=full. "
+    "Safe mode only deletes events dated tomorrow or later, to absorb "
+    "server-vs-athlete timezone skew. This is a server-side env var set by the "
+    "operator, not a tool parameter."
+)
+MISSING_DATE_HINT = (
+    "Event has no start_date_local; cannot verify it is in the future. "
+    "Use INTERVALS_ICU_DELETE_MODE=full to override."
+)
+
+
+def _classify_event_date(start_date_local: str | None) -> str:
+    """Classify an event's date for safe-mode gating.
+
+    Compares at date granularity (planned events typically lack meaningful times).
+    Today is classified as 'past' so safe mode only deletes events dated tomorrow
+    or later. The one-day buffer absorbs server-vs-athlete timezone skew (e.g.,
+    UTC server with non-UTC athlete profile) without an extra API call.
+
+    Returns one of: 'future', 'past', 'unknown'.
+    """
+    if not start_date_local:
+        return "unknown"
+    try:
+        parsed = datetime.fromisoformat(start_date_local).date()
+    except (ValueError, TypeError):
+        return "unknown"
+    return "future" if parsed > date.today() else "past"
+
+
+def _delete_envelope(
+    deleted: list[int],
+    skipped: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the uniform deleted/skipped response envelope."""
+    return {
+        "deleted": deleted,
+        "deleted_count": len(deleted),
+        "skipped": skipped,
+        "skipped_count": len(skipped),
+    }
+
+
+def _skipped_entry_for(event_id: int, event: Event | None) -> dict[str, Any]:
+    """Build a `skipped` entry for an event refused in safe mode."""
+    classification = _classify_event_date(event.start_date_local if event else None)
+    if classification == "past":
+        return {
+            "id": event_id,
+            "reason": "past_event",
+            "start_date_local": event.start_date_local if event else None,
+            "hint": PAST_EVENT_HINT,
+        }
+    return {
+        "id": event_id,
+        "reason": "missing_date",
+        "start_date_local": event.start_date_local if event else None,
+        "hint": MISSING_DATE_HINT,
+    }
 
 VALID_CATEGORIES = {
     "WORKOUT",
@@ -402,30 +464,45 @@ async def delete_event(
 
     Permanently removes an event from your calendar. This action cannot be undone.
 
+    In `safe` delete mode (the default), past events are refused — only events
+    dated today or later are deletable. The skipped event is reported in the
+    response with its date and a hint pointing the operator to
+    INTERVALS_ICU_DELETE_MODE=full if they need to delete past events.
+
     Args:
         event_id: ID of the event to delete
 
     Returns:
-        JSON string with deletion confirmation
+        JSON string with `deleted` / `skipped` envelope
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
-            success = await client.delete_event(event_id, athlete_id=athlete_id)
+            if config.intervals_icu_delete_mode == "safe":
+                event = await client.get_event(event_id, athlete_id=athlete_id)
+                if _classify_event_date(event.start_date_local) != "future":
+                    return ResponseBuilder.build_response(
+                        data=_delete_envelope(
+                            deleted=[],
+                            skipped=[_skipped_entry_for(event_id, event)],
+                        ),
+                        query_type="delete_event",
+                        metadata={"message": f"Skipped event {event_id} in safe mode"},
+                    )
 
-            if success:
-                return ResponseBuilder.build_response(
-                    data={"event_id": event_id, "deleted": True},
-                    query_type="delete_event",
-                    metadata={"message": f"Successfully deleted event {event_id}"},
-                )
-            else:
+            success = await client.delete_event(event_id, athlete_id=athlete_id)
+            if not success:
                 return ResponseBuilder.build_error_response(
                     f"Failed to delete event {event_id}",
                     error_type="api_error",
                 )
+            return ResponseBuilder.build_response(
+                data=_delete_envelope(deleted=[event_id], skipped=[]),
+                query_type="delete_event",
+                metadata={"message": f"Successfully deleted event {event_id}"},
+            )
 
     except ICUAPIError as e:
         return ResponseBuilder.build_error_response(e.message, error_type="api_error")
@@ -579,11 +656,16 @@ async def bulk_delete_events(
     This is more efficient than deleting events one at a time. Provide a JSON array
     of event IDs to delete.
 
+    In `safe` delete mode (the default), past events are skipped — the call
+    partitions the input list into deleted (future) and skipped (past or
+    undated) and returns both. INTERVALS_ICU_DELETE_MODE=full disables the
+    partition and deletes everything.
+
     Args:
         event_ids: JSON array of event IDs (integers)
 
     Returns:
-        JSON string with deletion confirmation
+        JSON string with `deleted` / `skipped` envelope
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -591,7 +673,6 @@ async def bulk_delete_events(
     try:
         import json
 
-        # Parse the JSON string
         try:
             parsed_data = json.loads(event_ids)
         except json.JSONDecodeError as e:
@@ -609,14 +690,46 @@ async def bulk_delete_events(
                 "Must provide at least one event ID to delete", error_type="validation_error"
             )
 
-        # Type cast after validation
         ids_list: list[int] = parsed_data  # type: ignore[assignment]
 
         async with ICUClient(config) as client:
-            result = await client.bulk_delete_events(ids_list, athlete_id=athlete_id)
+            if config.intervals_icu_delete_mode == "safe":
+                fetched = await asyncio.gather(
+                    *(client.get_event(eid, athlete_id=athlete_id) for eid in ids_list),
+                    return_exceptions=True,
+                )
 
+                ids_to_delete: list[int] = []
+                skipped: list[dict[str, Any]] = []
+                for eid, fetched_event in zip(ids_list, fetched, strict=True):
+                    if isinstance(fetched_event, BaseException):
+                        if isinstance(fetched_event, ICUAPIError):
+                            return ResponseBuilder.build_error_response(
+                                fetched_event.message, error_type="api_error"
+                            )
+                        raise fetched_event
+                    if _classify_event_date(fetched_event.start_date_local) == "future":
+                        ids_to_delete.append(eid)
+                    else:
+                        skipped.append(_skipped_entry_for(eid, fetched_event))
+
+                if ids_to_delete:
+                    await client.bulk_delete_events(ids_to_delete, athlete_id=athlete_id)
+
+                return ResponseBuilder.build_response(
+                    data=_delete_envelope(deleted=ids_to_delete, skipped=skipped),
+                    query_type="bulk_delete_events",
+                    metadata={
+                        "message": (
+                            f"Deleted {len(ids_to_delete)} event(s); "
+                            f"skipped {len(skipped)} in safe mode"
+                        ),
+                    },
+                )
+
+            await client.bulk_delete_events(ids_list, athlete_id=athlete_id)
             return ResponseBuilder.build_response(
-                data={"deleted_count": len(ids_list), "event_ids": ids_list, "result": result},
+                data=_delete_envelope(deleted=ids_list, skipped=[]),
                 query_type="bulk_delete_events",
                 metadata={"message": f"Successfully deleted {len(ids_list)} events"},
             )

--- a/tests/test_delete_mode.py
+++ b/tests/test_delete_mode.py
@@ -1,0 +1,107 @@
+"""Tests for INTERVALS_ICU_DELETE_MODE config and conditional tool registration."""
+
+import asyncio
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from intervals_icu_mcp.auth import ICUConfig
+
+
+class TestDeleteModeValidation:
+    def test_default_is_safe(self, monkeypatch):
+        monkeypatch.delenv("INTERVALS_ICU_DELETE_MODE", raising=False)
+        cfg = ICUConfig(intervals_icu_api_key="k", intervals_icu_athlete_id="a")
+        assert cfg.intervals_icu_delete_mode == "safe"
+
+    def test_accepts_full(self):
+        cfg = ICUConfig(
+            intervals_icu_api_key="k",
+            intervals_icu_athlete_id="a",
+            intervals_icu_delete_mode="full",
+        )
+        assert cfg.intervals_icu_delete_mode == "full"
+
+    def test_accepts_none(self):
+        cfg = ICUConfig(
+            intervals_icu_api_key="k",
+            intervals_icu_athlete_id="a",
+            intervals_icu_delete_mode="none",
+        )
+        assert cfg.intervals_icu_delete_mode == "none"
+
+    def test_normalizes_case_and_whitespace(self):
+        cfg = ICUConfig.model_validate(
+            {
+                "intervals_icu_api_key": "k",
+                "intervals_icu_athlete_id": "a",
+                "intervals_icu_delete_mode": "  FULL  ",
+            }
+        )
+        assert cfg.intervals_icu_delete_mode == "full"
+
+    def test_rejects_invalid_value(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ICUConfig.model_validate(
+                {
+                    "intervals_icu_api_key": "k",
+                    "intervals_icu_athlete_id": "a",
+                    "intervals_icu_delete_mode": "banana",
+                }
+            )
+        message = str(exc_info.value)
+        assert "INTERVALS_ICU_DELETE_MODE must be one of" in message
+        assert "banana" in message
+
+
+def _reload_server() -> object:
+    """Re-import the server module so module-level registration re-runs."""
+    sys.modules.pop("intervals_icu_mcp.server", None)
+    return importlib.import_module("intervals_icu_mcp.server")
+
+
+class TestConditionalRegistration:
+    """Each mode registers a different set of delete tools."""
+
+    @staticmethod
+    def _tool_names(server_module: object) -> set[str]:
+        tools = asyncio.run(server_module.mcp.list_tools())  # type: ignore[attr-defined]
+        return {t.name for t in tools}
+
+    def test_safe_mode_registers_event_and_gear_only(self, monkeypatch):
+        monkeypatch.setenv("INTERVALS_ICU_DELETE_MODE", "safe")
+        names = self._tool_names(_reload_server())
+        assert "icu_delete_event" in names
+        assert "icu_bulk_delete_events" in names
+        assert "icu_delete_gear" in names
+        assert "icu_delete_activity" not in names
+        assert "icu_delete_sport_settings" not in names
+        assert "icu_delete_custom_item" not in names
+
+    def test_full_mode_registers_all_delete_tools(self, monkeypatch):
+        monkeypatch.setenv("INTERVALS_ICU_DELETE_MODE", "full")
+        names = self._tool_names(_reload_server())
+        for tool in (
+            "icu_delete_event",
+            "icu_bulk_delete_events",
+            "icu_delete_gear",
+            "icu_delete_activity",
+            "icu_delete_sport_settings",
+            "icu_delete_custom_item",
+        ):
+            assert tool in names, f"expected {tool} registered in full mode"
+
+    def test_none_mode_registers_no_delete_tools(self, monkeypatch):
+        monkeypatch.setenv("INTERVALS_ICU_DELETE_MODE", "none")
+        names = self._tool_names(_reload_server())
+        for tool in (
+            "icu_delete_event",
+            "icu_bulk_delete_events",
+            "icu_delete_gear",
+            "icu_delete_activity",
+            "icu_delete_sport_settings",
+            "icu_delete_custom_item",
+        ):
+            assert tool not in names, f"expected {tool} NOT registered in none mode"

--- a/tests/test_event_tools.py
+++ b/tests/test_event_tools.py
@@ -1,10 +1,13 @@
 """Tests for event management tools."""
 
 import json
+from datetime import date, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from httpx import Response
 
+from intervals_icu_mcp.auth import ICUConfig
 from intervals_icu_mcp.tools.event_management import (
     apply_training_plan,
     bulk_create_events,
@@ -14,6 +17,24 @@ from intervals_icu_mcp.tools.event_management import (
     duplicate_events,
     update_event,
 )
+
+
+def _future_date(days: int = 7) -> str:
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+def _past_date(days: int = 7) -> str:
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+@pytest.fixture
+def mock_config_full():
+    """Config with delete_mode=full for tests that bypass the safe-mode guard."""
+    return ICUConfig(
+        intervals_icu_api_key="test_api_key_12345",
+        intervals_icu_athlete_id="i123456",
+        intervals_icu_delete_mode="full",
+    )
 
 
 class TestEventTools:
@@ -78,22 +99,131 @@ class TestEventTools:
         assert response["data"]["name"] == "Updated Workout"
         assert response["metadata"]["message"] == "Successfully updated event 1001"
 
-    async def test_delete_event_success(self, mock_config, respx_mock):
-        """Test successful event deletion."""
+    async def test_delete_event_safe_allows_future(self, mock_config, respx_mock):
+        """Safe mode (default): future event is fetched, then deleted."""
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
+        respx_mock.get("/athlete/i123456/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": _future_date(),
+                    "name": "Tomorrow's workout",
+                    "category": "WORKOUT",
+                },
+            )
+        )
         respx_mock.delete("/athlete/i123456/events/1001").mock(return_value=Response(200, json={}))
 
-        result = await delete_event(
-            event_id=1001,
-            ctx=mock_ctx,
-        )
+        result = await delete_event(event_id=1001, ctx=mock_ctx)
 
         response = json.loads(result)
         assert "data" in response
-        assert response["data"]["deleted"] is True
-        assert response["metadata"]["message"] == "Successfully deleted event 1001"
+        assert response["data"]["deleted"] == [1001]
+        assert response["data"]["deleted_count"] == 1
+        assert response["data"]["skipped"] == []
+        assert response["data"]["skipped_count"] == 0
+
+    async def test_delete_event_safe_refuses_past(self, mock_config, respx_mock):
+        """Safe mode: past event is skipped with reason=past_event."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        past = _past_date()
+        respx_mock.get("/athlete/i123456/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": past,
+                    "name": "Last week",
+                    "category": "WORKOUT",
+                },
+            )
+        )
+        delete_route = respx_mock.delete("/athlete/i123456/events/1001").mock(
+            return_value=Response(200, json={})
+        )
+
+        result = await delete_event(event_id=1001, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted"] == []
+        assert response["data"]["deleted_count"] == 0
+        assert len(response["data"]["skipped"]) == 1
+        skip = response["data"]["skipped"][0]
+        assert skip["id"] == 1001
+        assert skip["reason"] == "past_event"
+        assert skip["start_date_local"] == past
+        assert "INTERVALS_ICU_DELETE_MODE=full" in skip["hint"]
+        assert delete_route.call_count == 0
+
+    async def test_delete_event_safe_treats_today_as_past(self, mock_config, respx_mock):
+        """One-day buffer: today's events are refused to absorb TZ skew."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        today = date.today().isoformat()
+        respx_mock.get("/athlete/i123456/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": today,
+                    "name": "Today",
+                    "category": "WORKOUT",
+                },
+            )
+        )
+        delete_route = respx_mock.delete("/athlete/i123456/events/1001").mock(
+            return_value=Response(200, json={})
+        )
+
+        result = await delete_event(event_id=1001, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted"] == []
+        assert response["data"]["skipped"][0]["reason"] == "past_event"
+        assert delete_route.call_count == 0
+
+    async def test_delete_event_safe_skips_unparseable_date(self, mock_config, respx_mock):
+        """Safe mode: event with an unparseable date is skipped (cannot verify)."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": "not-a-date",
+                    "name": "Bad date",
+                    "category": "NOTE",
+                },
+            )
+        )
+
+        result = await delete_event(event_id=1001, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted_count"] == 0
+        assert response["data"]["skipped"][0]["reason"] == "missing_date"
+
+    async def test_delete_event_full_skips_date_check(self, mock_config_full, respx_mock):
+        """Full mode: no fetch, deletes regardless of date."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config_full)
+
+        get_route = respx_mock.get("/athlete/i123456/events/1001")
+        respx_mock.delete("/athlete/i123456/events/1001").mock(return_value=Response(200, json={}))
+
+        result = await delete_event(event_id=1001, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted"] == [1001]
+        assert get_route.call_count == 0
 
     async def test_apply_training_plan_success(self, mock_config, respx_mock):
         """Test successful training plan application."""
@@ -401,10 +531,10 @@ class TestEventTools:
         assert "error" in response
         assert "No fields provided" in response["error"]["message"]
 
-    async def test_delete_event_api_error(self, mock_config, respx_mock):
-        """API 404 on delete surfaces as error response."""
+    async def test_delete_event_api_error(self, mock_config_full, respx_mock):
+        """API 404 on delete surfaces as error response (full mode bypasses get_event)."""
         mock_ctx = MagicMock()
-        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+        mock_ctx.get_state = AsyncMock(return_value=mock_config_full)
 
         respx_mock.delete("/athlete/i123456/events/9999").mock(
             return_value=Response(404, json={"error": "Event not found"})
@@ -561,10 +691,10 @@ class TestEventTools:
         assert "error" in response
         assert "start_date_local" in response["error"]["message"]
 
-    async def test_bulk_delete_events_success(self, mock_config, respx_mock):
-        """Bulk delete events reports the deleted IDs."""
+    async def test_bulk_delete_events_full_mode(self, mock_config_full, respx_mock):
+        """Full mode: deletes all IDs without per-event date check."""
         mock_ctx = MagicMock()
-        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+        mock_ctx.get_state = AsyncMock(return_value=mock_config_full)
 
         respx_mock.put("/athlete/i123456/events/bulk-delete").mock(
             return_value=Response(200, json={"deleted": 2})
@@ -573,10 +703,84 @@ class TestEventTools:
         result = await bulk_delete_events(event_ids=json.dumps([1001, 1002]), ctx=mock_ctx)
 
         response = json.loads(result)
-        assert "data" in response
+        assert response["data"]["deleted"] == [1001, 1002]
         assert response["data"]["deleted_count"] == 2
-        assert response["data"]["event_ids"] == [1001, 1002]
+        assert response["data"]["skipped"] == []
         assert response["metadata"]["message"] == "Successfully deleted 2 events"
+
+    async def test_bulk_delete_events_safe_partition(self, mock_config, respx_mock):
+        """Safe mode: partitions input into deleted (future) and skipped (past)."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        future = _future_date()
+        past = _past_date()
+        respx_mock.get("/athlete/i123456/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": future,
+                    "name": "Future workout",
+                    "category": "WORKOUT",
+                },
+            )
+        )
+        respx_mock.get("/athlete/i123456/events/1002").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1002,
+                    "start_date_local": past,
+                    "name": "Past workout",
+                    "category": "WORKOUT",
+                },
+            )
+        )
+        bulk_route = respx_mock.put("/athlete/i123456/events/bulk-delete").mock(
+            return_value=Response(200, json={"deleted": 1})
+        )
+
+        result = await bulk_delete_events(event_ids=json.dumps([1001, 1002]), ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted"] == [1001]
+        assert response["data"]["deleted_count"] == 1
+        assert len(response["data"]["skipped"]) == 1
+        assert response["data"]["skipped"][0]["id"] == 1002
+        assert response["data"]["skipped"][0]["reason"] == "past_event"
+        sent = json.loads(bulk_route.calls.last.request.content)
+        sent_ids = [entry["id"] if isinstance(entry, dict) else entry for entry in sent]
+        assert sent_ids == [1001]
+
+    async def test_bulk_delete_events_safe_all_past(self, mock_config, respx_mock):
+        """Safe mode: when every input is past, no bulk-delete call is made."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        past = _past_date()
+        for eid in (1001, 1002):
+            respx_mock.get(f"/athlete/i123456/events/{eid}").mock(
+                return_value=Response(
+                    200,
+                    json={
+                        "id": eid,
+                        "start_date_local": past,
+                        "name": "Past",
+                        "category": "WORKOUT",
+                    },
+                )
+            )
+        bulk_route = respx_mock.put("/athlete/i123456/events/bulk-delete").mock(
+            return_value=Response(200, json={"deleted": 0})
+        )
+
+        result = await bulk_delete_events(event_ids=json.dumps([1001, 1002]), ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert response["data"]["deleted_count"] == 0
+        assert response["data"]["skipped_count"] == 2
+        assert bulk_route.call_count == 0
 
     async def test_bulk_delete_events_requires_non_empty(self, mock_config):
         """Validation: empty array is rejected."""

--- a/tests/test_multi_athlete_and_models.py
+++ b/tests/test_multi_athlete_and_models.py
@@ -151,6 +151,20 @@ class TestMultiAthleteEventManagement:
         assert COACH_ATHLETE in respx_mock.calls.last.request.url.path
 
     async def test_delete_event_with_athlete_id(self, mock_config, respx_mock):
+        from datetime import date, timedelta
+
+        future = (date.today() + timedelta(days=7)).isoformat()
+        respx_mock.get(f"/athlete/{COACH_ATHLETE}/events/1001").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 1001,
+                    "start_date_local": future,
+                    "name": "Future",
+                    "category": "WORKOUT",
+                },
+            )
+        )
         respx_mock.delete(f"/athlete/{COACH_ATHLETE}/events/1001").mock(
             return_value=Response(200, json={})
         )
@@ -159,7 +173,7 @@ class TestMultiAthleteEventManagement:
             event_id=1001, athlete_id=COACH_ATHLETE, ctx=make_ctx(mock_config)
         )
         response = json.loads(result)
-        assert response["data"]["deleted"] is True
+        assert response["data"]["deleted"] == [1001]
         assert COACH_ATHLETE in respx_mock.calls.last.request.url.path
 
     async def test_duplicate_events_with_athlete_id(self, mock_config, respx_mock, mock_event_data):
@@ -203,6 +217,21 @@ class TestMultiAthleteEventManagement:
         assert COACH_ATHLETE in respx_mock.calls.last.request.url.path
 
     async def test_bulk_delete_events_with_athlete_id(self, mock_config, respx_mock):
+        from datetime import date, timedelta
+
+        future = (date.today() + timedelta(days=7)).isoformat()
+        for eid in (2001, 2002):
+            respx_mock.get(f"/athlete/{COACH_ATHLETE}/events/{eid}").mock(
+                return_value=Response(
+                    200,
+                    json={
+                        "id": eid,
+                        "start_date_local": future,
+                        "name": f"E{eid}",
+                        "category": "WORKOUT",
+                    },
+                )
+            )
         respx_mock.put(f"/athlete/{COACH_ATHLETE}/events/bulk-delete").mock(
             return_value=Response(200, json={"deleted": 2})
         )
@@ -213,6 +242,7 @@ class TestMultiAthleteEventManagement:
             ctx=make_ctx(mock_config),
         )
         response = json.loads(result)
+        assert response["data"]["deleted"] == [2001, 2002]
         assert response["data"]["deleted_count"] == 2
         assert COACH_ATHLETE in respx_mock.calls.last.request.url.path
 

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -30,10 +30,11 @@ class TestInMemoryTransport:
         async with Client(mcp) as client:
             assert client.is_connected()
 
-    async def test_all_58_tools_registered(self):
+    async def test_all_default_mode_tools_registered(self):
+        """Default delete_mode=safe registers 55 tools (3 destructive tools gated)."""
         async with Client(mcp) as client:
             tools = await client.list_tools()
-            assert len(tools) == 58
+            assert len(tools) == 55
             names = {t.name for t in tools}
             # Spot-check tools from different modules / tiers
             assert "icu_get_recent_activities" in names
@@ -189,5 +190,5 @@ class TestHTTPTransport:
                 tools_body = (await tools_resp.aread()).decode()
                 tools_payload = self._parse_sse_response(tools_body)
                 tool_names = {t["name"] for t in tools_payload["result"]["tools"]}
-                assert len(tool_names) == 58
+                assert len(tool_names) == 55  # safe mode default
                 assert "icu_get_recent_activities" in tool_names

--- a/uv.lock
+++ b/uv.lock
@@ -453,12 +453,13 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -478,9 +479,18 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements #17. Adds `INTERVALS_ICU_DELETE_MODE` env var (`safe` / `full` / `none`, default `safe`) gating which destructive tools are *registered* with the server. The gate sits **outside the model's reach** — tools that aren't registered cannot be invoked by any prompt or parameter.

Safe mode refuses past-event deletion (today and earlier — one-day buffer absorbs server-vs-athlete TZ skew) and blocks `delete_activity` / `delete_sport_settings` / `delete_custom_item` entirely. `delete_gear` stays available since the API guarantees activities are unaffected when gear is removed.

| Mode | Registered tools | Events | Activities | Gear | Sport settings | Custom items |
|---|---|---|---|---|---|---|
| `safe` (default) | 55 | tomorrow or later | ✗ | ✓ | ✗ | ✗ |
| `full` | 58 | any date | ✓ | ✓ | ✓ | ✓ |
| `none` | 52 | ✗ | ✗ | ✗ | ✗ | ✗ |

## Breaking changes

- `delete_event` response shape replaced with `{deleted, deleted_count, skipped, skipped_count}` envelope
- `delete_activity`, `delete_sport_settings`, `delete_custom_item` no longer registered by default — set `INTERVALS_ICU_DELETE_MODE=full` to restore
- Sport-settings deletion is gated because current FTP/zones drive retroactive chart math (per the Intervals.icu developer on the forum)

## Other changes

- Backfilled CHANGELOG with previously-missing v1.0.2, v1.2.0, v1.3.0 entries; split conflated 1.0.1/1.0.2 content; folded the phantom (untagged) "1.1.1" entry into v1.2.0
- Bumped FastMCP 3.1.1 → 3.2.4
- Moved Delete Safety Mode reference + ChatGPT walkthrough to `docs/` to keep README under 300 lines (now 283)
- Added a *Releases* section to CLAUDE.md documenting the manual-CHANGELOG / tag-driven release flow, plus a README discipline guideline

## Test plan

- [x] `make can-release` passes (113 tests, ruff clean, pyright clean, pyroma 10/10)
- [x] Mode validation: invalid env value fails loud at startup
- [x] Tool counts verified per mode: `none` 52, `safe` 55, `full` 58
- [x] Safe mode: future event deleted, today refused, past refused, malformed-date refused, all without falling through to the delete API call
- [x] Bulk safe mode: mixed past+future partitions correctly with one extra `get_event` call per ID via `asyncio.gather`
- [ ] Smoke-test against a live Intervals.icu account before tagging the next release