### PR TITLE
chore(skills): expand commit skill with branch guard and PR flow

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: commit
 description: |
-  Analyze staged and unstaged changes, summarize intent, and create a
-  conventional commit message. Use when the user asks to commit, save work,
-  or says "commit this".
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+  Analyze changes, write a conventional commit, and (when shipping) open a
+  PR with closing keywords so referenced issues auto-close on merge. Use
+  when the user asks to commit, push, or open a PR.
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git switch:*), Bash(git checkout:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr edit:*), Bash(gh issue view:*), Bash(make can-release:*), Bash(make lint:*), Bash(make test:*), Bash(make format:*)
 ---
 
 ## Context
@@ -14,20 +14,76 @@ Gather the following before composing the commit message:
 - Current branch: `git branch --show-current`
 - Working tree status: `git status --short --branch`
 - Diff (staged + unstaged): `git diff $(git rev-parse --verify HEAD 2>/dev/null || echo --cached)`
-- Recent history (if available): `git log --oneline -10 || echo "No commits yet"`
+- Recent history: `git log --oneline -10`
+
+## Branch guard — MANDATORY first step
+
+**Never commit on `main`.** Before staging or committing:
+
+1. Run `git branch --show-current`.
+2. If the result is `main`:
+   - Propose a branch name derived from the commit type/scope (e.g. `fix/hr-histogram-list-shape`, `feat/event-tags`).
+   - Confirm the name with the user, then `git switch -c <branch>`.
+   - Only then proceed to stage + commit.
+3. If on any other branch, commit there as-is — do not create a new branch.
+
+No exceptions: trivial fixes, doc tweaks, one-liners — all go through a non-main branch.
+
+## Commit message rules
+
+- **Single line. No body. No `Co-Authored-By` / Claude attribution.** This applies to every commit in this repo, regardless of size.
+- Format: `type(scope): description` — [Conventional Commits](https://www.conventionalcommits.org).
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`.
+- Scope is optional but encouraged. Conventional scopes here: `tools`, `client`, `middleware`, `models`, `wellness`, `events`, `ci`, `release`, or a specific tool module name.
+- Do not put issue refs (`Closes #N`) in the commit message — those live in the PR body so GitHub auto-closes correctly on merge.
+
+## Doc + count sync
+
+For `feat`, `fix`, or anything user-visible, check whether docs need updating in the same commit:
+
+- **`CHANGELOG.md`** — add a bullet under `## [Unreleased]`. CHANGELOG is **manual** in this repo; nothing generates it. Group bullets under `### Added` / `### Changed` / `### Fixed` matching the existing style.
+- **Tool / resource / prompt counts** — if tools were added or removed, update the counts that appear in:
+  - `README.md` (header/intro line and any tool tables)
+  - `CLAUDE.md` (project overview line stating tool counts)
+  - `docs/tools.md` if the registered set changed
+- **README discipline** — keep `README.md` under 300 lines. If a new section would push past ~30 lines and isn't core onboarding, extract it to `docs/` and link from the README.
+- **SemVer flag** — if the change alters a response shape, removes a tool/parameter, or changes a default that drops tools (e.g. `INTERVALS_ICU_DELETE_MODE`), call it out in the PR body — this requires a major version bump per CLAUDE.md.
+- **Do not reference upstream/comparison repos** in commit messages, PR bodies, CHANGELOG, or README.
+
+## Pre-PR gate — MANDATORY before opening a PR
+
+Before any `gh pr create`, run the full release check:
+
+```bash
+make can-release
+```
+
+This runs `ruff` (lint + format check), `pyright` (type check), the pytest suite, and the coverage gate from `.github/workflows/test.yml`. CI runs the same thing on push — failing it locally means failing CI.
+
+If it fails:
+- Lint: `make format` auto-fixes most issues.
+- Tests: `make test/verbose` for full output; `make test/<keyword>` to narrow.
+- Fix, re-run `make can-release`, do not proceed to PR until it's green.
+
+**Tool-behavior changes** (anything in `src/intervals_icu_mcp/tools/` that changes inputs, outputs, or side-effects): `make can-release` proves the unit tests pass against mocked HTTP — it does **not** prove the tool behaves correctly against the real Intervals.icu API. For non-trivial tool changes, flag this in the PR body and note whether manual verification (via Claude Desktop / MCP Inspector against `make run`) was performed. Don't claim end-to-end verification you didn't do.
+
+## Pull request — closing keywords
+
+When opening a PR (`gh pr create` or user asks for one), put a closing keyword in the **PR body** for every issue this PR resolves. The PR body is the only place GitHub auto-closes from on merge.
+
+- **Auto-closes:** `Closes #N` / `Fixes #N` / `Resolves #N` (one per line, in the body)
+- **Does NOT auto-close:** `Implements`, `Addresses`, `Refs`, `Related to` — use these for issues the PR touches but doesn't fully resolve (e.g. ratchet/running-log issues like #4 that should stay open across multiple PRs)
+
+Find the issue # in the user's prompt, branch name, or recent conversation. If unclear, ask — don't guess. After creating, verify with `gh pr view <n> --json closingIssuesReferences`; if empty, fix with `gh pr edit <n> --body-file -`.
+
+PR title follows the same conventional-commit format as the commit message. Body uses the existing `.github/PULL_REQUEST_TEMPLATE.md` structure (Summary / Changes / Checklist / Test plan).
 
 ## Instructions
 
-1. Summarize the **intent** of the changes — what problem they solve or what feature they add.
-2. Create a **concise, conventional commit message** following [Conventional Commits](https://www.conventionalcommits.org):
-   - Format: `type(scope): description`
-   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`
-   - Scope is optional but encouraged (e.g., `tools`, `client`, `middleware`)
-3. **README**: For `feat` or `fix` commits, check if `README.md` needs updates:
-   - `## Changelog` — add a bullet for the new feature or fix
-   - Tool/resource/prompt tables and counts — update if tools, resources, or prompts were added/removed
-   - Usage examples — add examples for new capabilities
-   - Also update counts in `CLAUDE.md` if they changed
-4. Stage all relevant changes with `git add`.
-5. Commit with `git commit -m "<generated message>"`.
-6. If there are unrelated changes, suggest splitting into separate commits.
+1. Summarize the **intent** of the changes — what problem they solve or what they add.
+2. Check the branch guard. If on `main`, propose a branch and switch.
+3. Decide whether the doc + count sync applies and update those files in the same staging set.
+4. Stage with `git add` (specific paths, not `-A`).
+5. Commit with `git commit -m "type(scope): description"` — single line.
+6. If shipping: run the pre-PR gate, then `gh pr create` with closing keywords in the body, then verify `closingIssuesReferences`.
+7. If there are unrelated changes in the working tree, suggest splitting into separate commits.


### PR DESCRIPTION
## Summary

Expands `.claude/skills/commit/SKILL.md` from a 33-line commit-message helper into a full commit + PR workflow tailored to this repo's conventions.

## Changes

- **Branch guard** — refuse to commit on `main`; propose and switch to a topic branch first.
- **Commit message rules** — single-line conventional commits, no body, no Claude co-author line (matches the global rule in user memory).
- **Doc + count sync** — points at `CHANGELOG.md` `## [Unreleased]` (not a README section), tool/resource/prompt counts in `README.md` + `CLAUDE.md` + `docs/tools.md`, README ≤300-line discipline, and the SemVer flag for response-shape changes per `CLAUDE.md`.
- **Pre-PR gate** — `make can-release` must be green before `gh pr create`. Includes the auto-fix hints (`make format`, `make test/verbose`) and an explicit caveat that mocked-HTTP tests don't prove end-to-end correctness for tool changes.
- **Closing keywords** — mandates `Closes #N` / `Fixes #N` / `Resolves #N` in the **PR body** (not commit message) for auto-close on merge, plus a `closingIssuesReferences` verification step. Directly addresses recent issues where auto-close failed.
- **Allowed-tools** — expanded from `git add/status/commit` to cover branch ops, push, `gh pr` commands, `gh issue view`, and the `make` targets used by the gates.

## Checklist

- [x] `make can-release` — fails on 8 pre-existing test failures on `main` (`test_transport_integration`, `test_event_tools`, `test_delete_mode` — default-mode tool count asserts 55 but reality is 58). Verified on `origin/main` directly. Unrelated to this diff (markdown-only change to `.claude/skills/`). Worth a separate bug report.
- [x] No API keys / credentials touched
- [x] No tool / response / model changes — purely workflow documentation for future Claude sessions

## Test plan

- N/A — markdown-only change to a Claude Code skill file. Verified the frontmatter is valid by reading the file back through the skill loader.