### PR TITLE
ci: fix Claude review workflows to actually post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -32,4 +32,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+
+            When posting findings, prefer inline review comments anchored to the specific file and line via the mcp__github_inline_comment__create_inline_comment tool. Use ```suggestion blocks inside inline comments so reviewers can apply fixes with one click. Reserve top-level PR comments for the overall summary only.
+          show_full_output: true
+          claude_args: '--permission-mode acceptEdits'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

The Claude review workflows added in #37 ran successfully but never posted output, because the workflow `GITHUB_TOKEN` was scoped to **read-only** on `pull-requests` and `issues`. Without `write` on those scopes, the Claude action has no way to create review comments — the run completes silently. Also bumps `actions/checkout@v4` → `@v6` to clear the Node 20 deprecation warning that now shows on every run.

## Changes

**`.github/workflows/claude.yml`** (`@claude`-mention handler):
- `pull-requests: read` → `write`
- `issues: read` → `write`

**`.github/workflows/claude-code-review.yml`** (auto-review on PR open):
- `pull-requests: read` → `write`
- `issues: read` → `write`
- Triggers expanded: `[opened]` → `[opened, synchronize, ready_for_review, reopened]` so the review also fires on PR updates, not just initial open
- Prompt: append `--comment` to instruct the plugin to post findings, plus inline-comment guidance encouraging anchored review comments with ```suggestion blocks
- Add `claude_args: '--permission-mode acceptEdits'` and `show_full_output: true` to match the working configuration in another repo of mine

**Both files:** `actions/checkout@v4` → `@v6` (clears the Node 20 deprecation warning on the next run).

**Kept as-is:** the public-repo `if:` guards (`github.actor == github.repository_owner` plus the fork-blocking `head.repo.full_name == github.repository`). These are deliberate cost controls and shouldn't be loosened.

## Checklist

- [x] `make can-release` — not run for this PR; the diff is YAML-only and the same 8 pre-existing test failures noted in #42 are unrelated to workflow files
- [x] No API keys / credentials touched
- [x] No tool / response shape changes

## Test plan

- Once merged, the next PR opened (or this one once re-fired) should see a Claude review comment posted on the PR conversation tab. If still silent, check the workflow run logs for permission errors.
- `@claude` mentions on issues or PR comments should now produce a response comment (previously silent).