### PR TITLE
fix(histograms): replace fictional Histogram model with API-accurate Bucket list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> ⚠️ **Next release must be `v3.0.0`** — this section contains a response-shape breaking change (see `### Changed` below); per `CLAUDE.md`'s strict-SemVer rule, that requires a major bump.
+
 ### Fixed
 - Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of `{min, max, secs}` objects, not a wrapper object; the previous `Histogram`/`HistogramBin` models never matched the actual API (the OpenAPI spec advertises a richer shape that isn't populated by these endpoints). Replaced with a minimal `Bucket` model and added regression tests with real-shape payloads.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of buckets, not a wrapper object; the `Histogram`/`HistogramBin` models never matched the API. Replaced with a `Bucket` model matching the OpenAPI spec, and added regression tests with non-empty payloads.
+
+### Changed
+- **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), with `{min_*, max_*}` ranges derived from consecutive bucket starts (last bucket's width inferred from the first consecutive pair). Per-bucket `time_seconds` + `moving_time_seconds` replace the inaccurate `count` field — the API surfaces time-in-bucket, not raw sample counts.
+
 ## [2.0.0] — 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of buckets, not a wrapper object; the `Histogram`/`HistogramBin` models never matched the API. Replaced with a `Bucket` model matching the OpenAPI spec, and added regression tests with non-empty payloads.
+- Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of `{min, max, secs}` objects, not a wrapper object; the previous `Histogram`/`HistogramBin` models never matched the actual API (the OpenAPI spec advertises a richer shape that isn't populated by these endpoints). Replaced with a minimal `Bucket` model and added regression tests with real-shape payloads.
 
 ### Changed
-- **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), with `{min_*, max_*}` ranges derived from consecutive bucket starts (last bucket's width inferred from the first consecutive pair). Per-bucket `time_seconds` + `moving_time_seconds` replace the inaccurate `count` field — the API surfaces time-in-bucket, not raw sample counts.
+- **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), each shaped `{<metric>_range: {min_*, max_*}, time_seconds}` where boundaries come straight from the API's `min`/`max` fields. The previous `count` field is dropped (the API doesn't return raw sample counts — `secs` is time-in-bucket).
 
 ## [2.0.0] — 2026-04-29
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -13,12 +13,12 @@ from .models import (
     ActivitySummary,
     Athlete,
     BestEfforts,
+    Bucket,
     CurveSet,
     Event,
     Folder,
     Gear,
     GearReminder,
-    Histogram,
     Interval,
     IntervalsDTO,
     SportSettings,
@@ -368,62 +368,50 @@ class ICUClient:
     async def get_power_histogram(
         self,
         activity_id: str,
-    ) -> Histogram:
+    ) -> list[Bucket]:
         """Get power distribution histogram for an activity.
 
-        Args:
-            activity_id: Activity ID
-
-        Returns:
-            Histogram with power distribution bins
+        Returns a list of buckets sorted by `start` ascending. The endpoint
+        returns a bare JSON array, not an object — see `Bucket` for the shape.
         """
         response = await self._request("GET", f"/activity/{activity_id}/power-histogram")
-        return Histogram(**response.json())
+        return [Bucket(**b) for b in response.json()]
 
     async def get_hr_histogram(
         self,
         activity_id: str,
-    ) -> Histogram:
+    ) -> list[Bucket]:
         """Get heart rate distribution histogram for an activity.
 
-        Args:
-            activity_id: Activity ID
-
-        Returns:
-            Histogram with HR distribution bins
+        Returns a list of buckets sorted by `start` ascending. The endpoint
+        returns a bare JSON array, not an object — see `Bucket` for the shape.
         """
         response = await self._request("GET", f"/activity/{activity_id}/hr-histogram")
-        return Histogram(**response.json())
+        return [Bucket(**b) for b in response.json()]
 
     async def get_pace_histogram(
         self,
         activity_id: str,
-    ) -> Histogram:
+    ) -> list[Bucket]:
         """Get pace distribution histogram for an activity.
 
-        Args:
-            activity_id: Activity ID
-
-        Returns:
-            Histogram with pace distribution bins
+        Returns a list of buckets sorted by `start` ascending. The endpoint
+        returns a bare JSON array, not an object — see `Bucket` for the shape.
         """
         response = await self._request("GET", f"/activity/{activity_id}/pace-histogram")
-        return Histogram(**response.json())
+        return [Bucket(**b) for b in response.json()]
 
     async def get_gap_histogram(
         self,
         activity_id: str,
-    ) -> Histogram:
+    ) -> list[Bucket]:
         """Get grade-adjusted pace (GAP) histogram for an activity.
 
-        Args:
-            activity_id: Activity ID
-
-        Returns:
-            Histogram with GAP distribution bins
+        Returns a list of buckets sorted by `start` ascending. The endpoint
+        returns a bare JSON array, not an object — see `Bucket` for the shape.
         """
         response = await self._request("GET", f"/activity/{activity_id}/gap-histogram")
-        return Histogram(**response.json())
+        return [Bucket(**b) for b in response.json()]
 
     # ==================== Wellness Endpoints ====================
 

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -461,16 +461,12 @@ class Bucket(BaseModel):
     """One bucket in a histogram returned by the Intervals.icu API.
 
     The API returns histogram endpoints as a bare JSON array of these buckets,
-    sorted by `start` ascending. Each bucket spans from `start` up to the next
-    bucket's `start` (the last bucket's width must be inferred). `secs` and
-    `moving_secs` carry time-in-bucket, not a raw sample count.
+    sorted by `min` ascending. `secs` is time-in-bucket; the API does not
+    return raw sample counts or per-bucket moving time. (The OpenAPI spec
+    documents a richer shape with `start`/`movingSecs`/etc. — those fields are
+    not actually populated by any of the histogram endpoints.)
     """
 
-    start: float | None = None
+    min: float | None = None
+    max: float | None = None
     secs: int | None = None
-    moving_secs: int | None = Field(default=None, alias="movingSecs")
-    watts: float | None = None
-    hr: float | None = None
-    cadence: int | None = None
-
-    model_config = ConfigDict(populate_by_name=True)

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -457,18 +457,20 @@ class Gear(BaseModel):
 # ==================== Histogram Models ====================
 
 
-class HistogramBin(BaseModel):
-    """Single bin in a histogram."""
+class Bucket(BaseModel):
+    """One bucket in a histogram returned by the Intervals.icu API.
 
-    min: float  # Minimum value for this bin
-    max: float  # Maximum value for this bin
-    count: int  # Number of data points in this bin
-    secs: int | None = None  # Time spent in this bin (seconds)
+    The API returns histogram endpoints as a bare JSON array of these buckets,
+    sorted by `start` ascending. Each bucket spans from `start` up to the next
+    bucket's `start` (the last bucket's width must be inferred). `secs` and
+    `moving_secs` carry time-in-bucket, not a raw sample count.
+    """
 
+    start: float | None = None
+    secs: int | None = None
+    moving_secs: int | None = Field(default=None, alias="movingSecs")
+    watts: float | None = None
+    hr: float | None = None
+    cadence: int | None = None
 
-class Histogram(BaseModel):
-    """Histogram data for activity metrics."""
-
-    bins: list[HistogramBin] = Field(default_factory=list[HistogramBin])
-    total_count: int | None = None
-    total_secs: int | None = None
+    model_config = ConfigDict(populate_by_name=True)

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -391,7 +391,7 @@ async def get_power_histogram(
         activity_id: The unique ID of the activity
 
     Returns:
-        JSON string with power distribution bins
+        JSON with `buckets` (each `{power_range: {min_watts, max_watts}, time_seconds}`) and `total_time_seconds`.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -453,7 +453,7 @@ async def get_hr_histogram(
         activity_id: The unique ID of the activity
 
     Returns:
-        JSON string with HR distribution bins
+        JSON with `buckets` (each `{hr_range: {min_bpm, max_bpm}, time_seconds}`) and `total_time_seconds`.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -515,7 +515,7 @@ async def get_pace_histogram(
         activity_id: The unique ID of the activity
 
     Returns:
-        JSON string with pace distribution bins
+        JSON with `buckets` (each `{pace_range: {min, max}, time_seconds}`) and `total_time_seconds`.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -574,7 +574,7 @@ async def get_gap_histogram(
         activity_id: The unique ID of the activity
 
     Returns:
-        JSON string with GAP distribution bins
+        JSON with `buckets` (each `{gap_range: {min, max}, time_seconds}`) and `total_time_seconds`.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -6,27 +6,8 @@ from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
-from ..models import Bucket
 from ..response_builder import ResponseBuilder
 from ._strava import fetch_strava_limitation_note
-
-
-def _bucket_end(buckets: list[Bucket], i: int) -> float | None:
-    """Return the upper bound of bucket `i`.
-
-    Uses the next bucket's `start` as the end. For the last bucket the API
-    gives us no explicit end, so we infer a uniform width from the first
-    consecutive pair of starts and project it onto the last bucket.
-    """
-    if i + 1 < len(buckets) and buckets[i + 1].start is not None:
-        return buckets[i + 1].start
-    starts = [b.start for b in buckets if b.start is not None]
-    if len(starts) < 2 or buckets[i].start is None:
-        return None
-    width = starts[1] - starts[0]
-    if width <= 0:
-        return None
-    return buckets[i].start + width
 
 
 async def get_activity_streams(
@@ -430,25 +411,22 @@ async def get_power_histogram(
                     metadata={"message": "No power histogram data available for this activity"},
                 )
 
-            buckets_data: list[dict[str, Any]] = []
-            for i, b in enumerate(buckets):
-                end = _bucket_end(buckets, i)
-                bucket_data: dict[str, Any] = {
+            buckets_data: list[dict[str, Any]] = [
+                {
                     "power_range": {
-                        "min_watts": int(b.start) if b.start is not None else None,
-                        "max_watts": int(end) if end is not None else None,
+                        "min_watts": int(b.min) if b.min is not None else None,
+                        "max_watts": int(b.max) if b.max is not None else None,
                     },
                     "time_seconds": b.secs or 0,
-                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                buckets_data.append(bucket_data)
+                for b in buckets
+            ]
 
             return ResponseBuilder.build_response(
                 data={
                     "activity_id": activity_id,
                     "buckets": buckets_data,
                     "total_time_seconds": sum(b.secs or 0 for b in buckets),
-                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
                 },
                 query_type="power_histogram",
             )
@@ -495,25 +473,22 @@ async def get_hr_histogram(
                     metadata={"message": "No HR histogram data available for this activity"},
                 )
 
-            buckets_data: list[dict[str, Any]] = []
-            for i, b in enumerate(buckets):
-                end = _bucket_end(buckets, i)
-                bucket_data: dict[str, Any] = {
+            buckets_data: list[dict[str, Any]] = [
+                {
                     "hr_range": {
-                        "min_bpm": int(b.start) if b.start is not None else None,
-                        "max_bpm": int(end) if end is not None else None,
+                        "min_bpm": int(b.min) if b.min is not None else None,
+                        "max_bpm": int(b.max) if b.max is not None else None,
                     },
                     "time_seconds": b.secs or 0,
-                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                buckets_data.append(bucket_data)
+                for b in buckets
+            ]
 
             return ResponseBuilder.build_response(
                 data={
                     "activity_id": activity_id,
                     "buckets": buckets_data,
                     "total_time_seconds": sum(b.secs or 0 for b in buckets),
-                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
                 },
                 query_type="hr_histogram",
             )
@@ -560,22 +535,19 @@ async def get_pace_histogram(
                     metadata={"message": "No pace histogram data available for this activity"},
                 )
 
-            buckets_data: list[dict[str, Any]] = []
-            for i, b in enumerate(buckets):
-                end = _bucket_end(buckets, i)
-                bucket_data: dict[str, Any] = {
-                    "pace_range": {"start": b.start, "end": end},
+            buckets_data: list[dict[str, Any]] = [
+                {
+                    "pace_range": {"min": b.min, "max": b.max},
                     "time_seconds": b.secs or 0,
-                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                buckets_data.append(bucket_data)
+                for b in buckets
+            ]
 
             return ResponseBuilder.build_response(
                 data={
                     "activity_id": activity_id,
                     "buckets": buckets_data,
                     "total_time_seconds": sum(b.secs or 0 for b in buckets),
-                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
                 },
                 query_type="pace_histogram",
             )
@@ -622,22 +594,19 @@ async def get_gap_histogram(
                     metadata={"message": "No GAP histogram data available for this activity"},
                 )
 
-            buckets_data: list[dict[str, Any]] = []
-            for i, b in enumerate(buckets):
-                end = _bucket_end(buckets, i)
-                bucket_data: dict[str, Any] = {
-                    "gap_range": {"start": b.start, "end": end},
+            buckets_data: list[dict[str, Any]] = [
+                {
+                    "gap_range": {"min": b.min, "max": b.max},
                     "time_seconds": b.secs or 0,
-                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                buckets_data.append(bucket_data)
+                for b in buckets
+            ]
 
             return ResponseBuilder.build_response(
                 data={
                     "activity_id": activity_id,
                     "buckets": buckets_data,
                     "total_time_seconds": sum(b.secs or 0 for b in buckets),
-                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
                     "note": "GAP (Grade Adjusted Pace) normalizes pace for elevation changes",
                 },
                 query_type="gap_histogram",

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -6,8 +6,27 @@ from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
+from ..models import Bucket
 from ..response_builder import ResponseBuilder
 from ._strava import fetch_strava_limitation_note
+
+
+def _bucket_end(buckets: list[Bucket], i: int) -> float | None:
+    """Return the upper bound of bucket `i`.
+
+    Uses the next bucket's `start` as the end. For the last bucket the API
+    gives us no explicit end, so we infer a uniform width from the first
+    consecutive pair of starts and project it onto the last bucket.
+    """
+    if i + 1 < len(buckets) and buckets[i + 1].start is not None:
+        return buckets[i + 1].start
+    starts = [b.start for b in buckets if b.start is not None]
+    if len(starts) < 2 or buckets[i].start is None:
+        return None
+    width = starts[1] - starts[0]
+    if width <= 0:
+        return None
+    return buckets[i].start + width
 
 
 async def get_activity_streams(
@@ -398,39 +417,39 @@ async def get_power_histogram(
 
     try:
         async with ICUClient(config) as client:
-            histogram = await client.get_power_histogram(activity_id)
+            buckets = await client.get_power_histogram(activity_id)
 
-            if not histogram.bins:
+            if not buckets:
                 analysis: dict[str, Any] = {}
                 strava_note = await fetch_strava_limitation_note(client, activity_id)
                 if strava_note:
                     analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
-                    data={"histogram": [], "activity_id": activity_id},
+                    data={"buckets": [], "activity_id": activity_id},
                     analysis=analysis if analysis else None,
                     metadata={"message": "No power histogram data available for this activity"},
                 )
 
-            bins_data: list[dict[str, Any]] = []
-            for bin_item in histogram.bins:
-                bin_data: dict[str, Any] = {
-                    "power_range": {"min_watts": int(bin_item.min), "max_watts": int(bin_item.max)},
-                    "count": bin_item.count,
+            buckets_data: list[dict[str, Any]] = []
+            for i, b in enumerate(buckets):
+                end = _bucket_end(buckets, i)
+                bucket_data: dict[str, Any] = {
+                    "power_range": {
+                        "min_watts": int(b.start) if b.start is not None else None,
+                        "max_watts": int(end) if end is not None else None,
+                    },
+                    "time_seconds": b.secs or 0,
+                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                if bin_item.secs is not None:
-                    bin_data["time_seconds"] = bin_item.secs
-                bins_data.append(bin_data)
-
-            result_data = {
-                "activity_id": activity_id,
-                "bins": bins_data,
-                "total_samples": histogram.total_count,
-            }
-            if histogram.total_secs is not None:
-                result_data["total_time_seconds"] = histogram.total_secs
+                buckets_data.append(bucket_data)
 
             return ResponseBuilder.build_response(
-                data=result_data,
+                data={
+                    "activity_id": activity_id,
+                    "buckets": buckets_data,
+                    "total_time_seconds": sum(b.secs or 0 for b in buckets),
+                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
+                },
                 query_type="power_histogram",
             )
 
@@ -463,39 +482,39 @@ async def get_hr_histogram(
 
     try:
         async with ICUClient(config) as client:
-            histogram = await client.get_hr_histogram(activity_id)
+            buckets = await client.get_hr_histogram(activity_id)
 
-            if not histogram.bins:
+            if not buckets:
                 analysis: dict[str, Any] = {}
                 strava_note = await fetch_strava_limitation_note(client, activity_id)
                 if strava_note:
                     analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
-                    data={"histogram": [], "activity_id": activity_id},
+                    data={"buckets": [], "activity_id": activity_id},
                     analysis=analysis if analysis else None,
                     metadata={"message": "No HR histogram data available for this activity"},
                 )
 
-            bins_data: list[dict[str, Any]] = []
-            for bin_item in histogram.bins:
-                bin_data: dict[str, Any] = {
-                    "hr_range": {"min_bpm": int(bin_item.min), "max_bpm": int(bin_item.max)},
-                    "count": bin_item.count,
+            buckets_data: list[dict[str, Any]] = []
+            for i, b in enumerate(buckets):
+                end = _bucket_end(buckets, i)
+                bucket_data: dict[str, Any] = {
+                    "hr_range": {
+                        "min_bpm": int(b.start) if b.start is not None else None,
+                        "max_bpm": int(end) if end is not None else None,
+                    },
+                    "time_seconds": b.secs or 0,
+                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                if bin_item.secs is not None:
-                    bin_data["time_seconds"] = bin_item.secs
-                bins_data.append(bin_data)
-
-            result_data = {
-                "activity_id": activity_id,
-                "bins": bins_data,
-                "total_samples": histogram.total_count,
-            }
-            if histogram.total_secs is not None:
-                result_data["total_time_seconds"] = histogram.total_secs
+                buckets_data.append(bucket_data)
 
             return ResponseBuilder.build_response(
-                data=result_data,
+                data={
+                    "activity_id": activity_id,
+                    "buckets": buckets_data,
+                    "total_time_seconds": sum(b.secs or 0 for b in buckets),
+                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
+                },
                 query_type="hr_histogram",
             )
 
@@ -528,50 +547,36 @@ async def get_pace_histogram(
 
     try:
         async with ICUClient(config) as client:
-            histogram = await client.get_pace_histogram(activity_id)
+            buckets = await client.get_pace_histogram(activity_id)
 
-            if not histogram.bins:
+            if not buckets:
                 analysis: dict[str, Any] = {}
                 strava_note = await fetch_strava_limitation_note(client, activity_id)
                 if strava_note:
                     analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
-                    data={"histogram": [], "activity_id": activity_id},
+                    data={"buckets": [], "activity_id": activity_id},
                     analysis=analysis if analysis else None,
                     metadata={"message": "No pace histogram data available for this activity"},
                 )
 
-            bins_data: list[dict[str, Any]] = []
-            for bin_item in histogram.bins:
-                # Convert pace from min/km to formatted string
-                min_minutes = int(bin_item.min)
-                min_seconds = int((bin_item.min - min_minutes) * 60)
-                max_minutes = int(bin_item.max)
-                max_seconds = int((bin_item.max - max_minutes) * 60)
-
-                bin_data: dict[str, Any] = {
-                    "pace_range": {
-                        "min_pace_min_per_km": bin_item.min,
-                        "max_pace_min_per_km": bin_item.max,
-                        "min_pace_formatted": f"{min_minutes}:{min_seconds:02d} /km",
-                        "max_pace_formatted": f"{max_minutes}:{max_seconds:02d} /km",
-                    },
-                    "count": bin_item.count,
+            buckets_data: list[dict[str, Any]] = []
+            for i, b in enumerate(buckets):
+                end = _bucket_end(buckets, i)
+                bucket_data: dict[str, Any] = {
+                    "pace_range": {"start": b.start, "end": end},
+                    "time_seconds": b.secs or 0,
+                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                if bin_item.secs is not None:
-                    bin_data["time_seconds"] = bin_item.secs
-                bins_data.append(bin_data)
-
-            result_data = {
-                "activity_id": activity_id,
-                "bins": bins_data,
-                "total_samples": histogram.total_count,
-            }
-            if histogram.total_secs is not None:
-                result_data["total_time_seconds"] = histogram.total_secs
+                buckets_data.append(bucket_data)
 
             return ResponseBuilder.build_response(
-                data=result_data,
+                data={
+                    "activity_id": activity_id,
+                    "buckets": buckets_data,
+                    "total_time_seconds": sum(b.secs or 0 for b in buckets),
+                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
+                },
                 query_type="pace_histogram",
             )
 
@@ -604,51 +609,37 @@ async def get_gap_histogram(
 
     try:
         async with ICUClient(config) as client:
-            histogram = await client.get_gap_histogram(activity_id)
+            buckets = await client.get_gap_histogram(activity_id)
 
-            if not histogram.bins:
+            if not buckets:
                 analysis: dict[str, Any] = {}
                 strava_note = await fetch_strava_limitation_note(client, activity_id)
                 if strava_note:
                     analysis["data_availability"] = strava_note
                 return ResponseBuilder.build_response(
-                    data={"histogram": [], "activity_id": activity_id},
+                    data={"buckets": [], "activity_id": activity_id},
                     analysis=analysis if analysis else None,
                     metadata={"message": "No GAP histogram data available for this activity"},
                 )
 
-            bins_data: list[dict[str, Any]] = []
-            for bin_item in histogram.bins:
-                # Convert GAP from min/km to formatted string
-                min_minutes = int(bin_item.min)
-                min_seconds = int((bin_item.min - min_minutes) * 60)
-                max_minutes = int(bin_item.max)
-                max_seconds = int((bin_item.max - max_minutes) * 60)
-
-                bin_data: dict[str, Any] = {
-                    "gap_range": {
-                        "min_gap_min_per_km": bin_item.min,
-                        "max_gap_min_per_km": bin_item.max,
-                        "min_gap_formatted": f"{min_minutes}:{min_seconds:02d} /km",
-                        "max_gap_formatted": f"{max_minutes}:{max_seconds:02d} /km",
-                    },
-                    "count": bin_item.count,
+            buckets_data: list[dict[str, Any]] = []
+            for i, b in enumerate(buckets):
+                end = _bucket_end(buckets, i)
+                bucket_data: dict[str, Any] = {
+                    "gap_range": {"start": b.start, "end": end},
+                    "time_seconds": b.secs or 0,
+                    "moving_time_seconds": b.moving_secs or 0,
                 }
-                if bin_item.secs is not None:
-                    bin_data["time_seconds"] = bin_item.secs
-                bins_data.append(bin_data)
-
-            result_data = {
-                "activity_id": activity_id,
-                "bins": bins_data,
-                "total_samples": histogram.total_count,
-                "note": "GAP (Grade Adjusted Pace) normalizes pace for elevation changes",
-            }
-            if histogram.total_secs is not None:
-                result_data["total_time_seconds"] = histogram.total_secs
+                buckets_data.append(bucket_data)
 
             return ResponseBuilder.build_response(
-                data=result_data,
+                data={
+                    "activity_id": activity_id,
+                    "buckets": buckets_data,
+                    "total_time_seconds": sum(b.secs or 0 for b in buckets),
+                    "total_moving_time_seconds": sum(b.moving_secs or 0 for b in buckets),
+                    "note": "GAP (Grade Adjusted Pace) normalizes pace for elevation changes",
+                },
                 query_type="gap_histogram",
             )
 

--- a/tests/test_histogram_tools.py
+++ b/tests/test_histogram_tools.py
@@ -1,10 +1,13 @@
 """Tests for histogram tools — power, HR, pace, GAP.
 
-Regression coverage for #39: the API returns a bare JSON array of Bucket
-objects (not a wrapper object), and `Bucket(**...)` was previously called as
-`Histogram(**...)`. Feeding non-empty payloads through end-to-end here would
-have caught the original bug; the previous Strava-stub tests mocked empty
-responses and never exercised deserialization.
+Regression coverage for #39: the API returns a bare JSON array of bucket
+objects shaped `{min, max, secs}` (not a wrapper object, not the richer shape
+the OpenAPI spec advertises). Feeding non-empty payloads through end-to-end
+here would have caught the original bug; the previous Strava-stub tests
+mocked empty responses and never exercised deserialization.
+
+The fixtures below mirror the actual `/activity/{id}/{hr,power,pace,gap}-histogram`
+responses observed against the live Intervals.icu API.
 """
 
 import json
@@ -22,18 +25,17 @@ from intervals_icu_mcp.tools.activity_analysis import (
 
 ACTIVITY_ID = "i123"
 
-# Realistic HR histogram payload: 5-bpm buckets from 60 to 90, time-in-bucket.
 HR_BUCKETS = [
-    {"start": 60, "secs": 120, "movingSecs": 120, "hr": 62.5, "watts": 0, "cadence": 0},
-    {"start": 65, "secs": 240, "movingSecs": 240, "hr": 67.5, "watts": 0, "cadence": 0},
-    {"start": 70, "secs": 600, "movingSecs": 540, "hr": 72.5, "watts": 0, "cadence": 0},
-    {"start": 75, "secs": 300, "movingSecs": 300, "hr": 77.5, "watts": 0, "cadence": 0},
+    {"min": 130, "max": 134, "secs": 2},
+    {"min": 135, "max": 139, "secs": 49},
+    {"min": 140, "max": 144, "secs": 210},
+    {"min": 145, "max": 149, "secs": 600},
 ]
 
 POWER_BUCKETS = [
-    {"start": 100, "secs": 60, "movingSecs": 60, "watts": 110, "hr": 0, "cadence": 0},
-    {"start": 150, "secs": 300, "movingSecs": 300, "watts": 165, "hr": 0, "cadence": 0},
-    {"start": 200, "secs": 90, "movingSecs": 90, "watts": 215, "hr": 0, "cadence": 0},
+    {"min": 0, "max": 24, "secs": 66},
+    {"min": 25, "max": 49, "secs": 300},
+    {"min": 50, "max": 74, "secs": 90},
 ]
 
 
@@ -53,10 +55,11 @@ class TestHrHistogram:
 
         assert data["activity_id"] == ACTIVITY_ID
         assert len(data["buckets"]) == 4
-        assert data["total_time_seconds"] == 120 + 240 + 600 + 300
-        assert data["total_moving_time_seconds"] == 120 + 240 + 540 + 300
+        assert data["total_time_seconds"] == 2 + 49 + 210 + 600
 
-    async def test_bucket_end_derived_from_next_start(self, mock_config, respx_mock):
+    async def test_bucket_boundaries_populated_from_api(self, mock_config, respx_mock):
+        """The bug after the first fix: min_bpm/max_bpm were null because the
+        model used `start` instead of the actual `min`/`max` API fields."""
         ctx = MagicMock()
         ctx.get_state = AsyncMock(return_value=mock_config)
 
@@ -67,14 +70,11 @@ class TestHrHistogram:
         result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
         buckets = json.loads(result)["data"]["buckets"]
 
-        # Middle buckets: end == next bucket's start.
-        assert buckets[0]["hr_range"] == {"min_bpm": 60, "max_bpm": 65}
-        assert buckets[1]["hr_range"] == {"min_bpm": 65, "max_bpm": 70}
-        assert buckets[2]["hr_range"] == {"min_bpm": 70, "max_bpm": 75}
-        # Last bucket: width inferred from the first consecutive pair (5 bpm).
-        assert buckets[3]["hr_range"] == {"min_bpm": 75, "max_bpm": 80}
+        assert buckets[0]["hr_range"] == {"min_bpm": 130, "max_bpm": 134}
+        assert buckets[1]["hr_range"] == {"min_bpm": 135, "max_bpm": 139}
+        assert buckets[3]["hr_range"] == {"min_bpm": 145, "max_bpm": 149}
 
-    async def test_per_bucket_times_surface(self, mock_config, respx_mock):
+    async def test_per_bucket_time_surfaces(self, mock_config, respx_mock):
         ctx = MagicMock()
         ctx.get_state = AsyncMock(return_value=mock_config)
 
@@ -85,12 +85,11 @@ class TestHrHistogram:
         result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
         buckets = json.loads(result)["data"]["buckets"]
 
-        # The middle bucket had moving_secs < secs (some non-moving time).
-        assert buckets[2]["time_seconds"] == 600
-        assert buckets[2]["moving_time_seconds"] == 540
+        assert buckets[2]["time_seconds"] == 210
+        assert buckets[3]["time_seconds"] == 600
 
     async def test_empty_payload_returns_empty_buckets(self, mock_config, respx_mock):
-        """Activity with no HR data — API returns [] (not {bins: []})."""
+        """Activity with no HR data — API returns []."""
         ctx = MagicMock()
         ctx.get_state = AsyncMock(return_value=mock_config)
 
@@ -127,11 +126,10 @@ class TestPowerHistogram:
         data = json.loads(result)["data"]
 
         assert len(data["buckets"]) == 3
-        assert data["buckets"][0]["power_range"] == {"min_watts": 100, "max_watts": 150}
-        assert data["buckets"][1]["power_range"] == {"min_watts": 150, "max_watts": 200}
-        # Last bucket: width inferred (50 W).
-        assert data["buckets"][2]["power_range"] == {"min_watts": 200, "max_watts": 250}
-        assert data["total_time_seconds"] == 60 + 300 + 90
+        assert data["buckets"][0]["power_range"] == {"min_watts": 0, "max_watts": 24}
+        assert data["buckets"][1]["power_range"] == {"min_watts": 25, "max_watts": 49}
+        assert data["buckets"][2]["power_range"] == {"min_watts": 50, "max_watts": 74}
+        assert data["total_time_seconds"] == 66 + 300 + 90
 
 
 @pytest.mark.asyncio
@@ -140,11 +138,9 @@ class TestPaceAndGapHistograms:
         ctx = MagicMock()
         ctx.get_state = AsyncMock(return_value=mock_config)
 
-        # Pace bucket `start` unit is API-defined; emit raw values without speculative formatting.
         payload = [
-            {"start": 240, "secs": 100, "movingSecs": 100},
-            {"start": 270, "secs": 400, "movingSecs": 400},
-            {"start": 300, "secs": 150, "movingSecs": 150},
+            {"min": 240, "max": 269, "secs": 100},
+            {"min": 270, "max": 299, "secs": 400},
         ]
         respx_mock.get(f"/activity/{ACTIVITY_ID}/pace-histogram").mock(
             return_value=Response(200, json=payload)
@@ -152,16 +148,16 @@ class TestPaceAndGapHistograms:
 
         result = await get_pace_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
         buckets = json.loads(result)["data"]["buckets"]
-        assert buckets[0]["pace_range"] == {"start": 240, "end": 270}
-        assert buckets[2]["pace_range"] == {"start": 300, "end": 330}
+        assert buckets[0]["pace_range"] == {"min": 240, "max": 269}
+        assert buckets[1]["pace_range"] == {"min": 270, "max": 299}
 
     async def test_gap_non_empty_payload_round_trips(self, mock_config, respx_mock):
         ctx = MagicMock()
         ctx.get_state = AsyncMock(return_value=mock_config)
 
         payload = [
-            {"start": 240, "secs": 200, "movingSecs": 200},
-            {"start": 270, "secs": 300, "movingSecs": 300},
+            {"min": 240, "max": 269, "secs": 200},
+            {"min": 270, "max": 299, "secs": 300},
         ]
         respx_mock.get(f"/activity/{ACTIVITY_ID}/gap-histogram").mock(
             return_value=Response(200, json=payload)
@@ -169,5 +165,5 @@ class TestPaceAndGapHistograms:
 
         result = await get_gap_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
         data = json.loads(result)["data"]
-        assert data["buckets"][0]["gap_range"] == {"start": 240, "end": 270}
+        assert data["buckets"][0]["gap_range"] == {"min": 240, "max": 269}
         assert "GAP" in data["note"]

--- a/tests/test_histogram_tools.py
+++ b/tests/test_histogram_tools.py
@@ -1,0 +1,173 @@
+"""Tests for histogram tools — power, HR, pace, GAP.
+
+Regression coverage for #39: the API returns a bare JSON array of Bucket
+objects (not a wrapper object), and `Bucket(**...)` was previously called as
+`Histogram(**...)`. Feeding non-empty payloads through end-to-end here would
+have caught the original bug; the previous Strava-stub tests mocked empty
+responses and never exercised deserialization.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import Response
+
+from intervals_icu_mcp.tools.activity_analysis import (
+    get_gap_histogram,
+    get_hr_histogram,
+    get_pace_histogram,
+    get_power_histogram,
+)
+
+ACTIVITY_ID = "i123"
+
+# Realistic HR histogram payload: 5-bpm buckets from 60 to 90, time-in-bucket.
+HR_BUCKETS = [
+    {"start": 60, "secs": 120, "movingSecs": 120, "hr": 62.5, "watts": 0, "cadence": 0},
+    {"start": 65, "secs": 240, "movingSecs": 240, "hr": 67.5, "watts": 0, "cadence": 0},
+    {"start": 70, "secs": 600, "movingSecs": 540, "hr": 72.5, "watts": 0, "cadence": 0},
+    {"start": 75, "secs": 300, "movingSecs": 300, "hr": 77.5, "watts": 0, "cadence": 0},
+]
+
+POWER_BUCKETS = [
+    {"start": 100, "secs": 60, "movingSecs": 60, "watts": 110, "hr": 0, "cadence": 0},
+    {"start": 150, "secs": 300, "movingSecs": 300, "watts": 165, "hr": 0, "cadence": 0},
+    {"start": 200, "secs": 90, "movingSecs": 90, "watts": 215, "hr": 0, "cadence": 0},
+]
+
+
+@pytest.mark.asyncio
+class TestHrHistogram:
+    async def test_non_empty_payload_round_trips(self, mock_config, respx_mock):
+        """Previously crashed with `argument after ** must be a mapping, not list`."""
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/hr-histogram").mock(
+            return_value=Response(200, json=HR_BUCKETS)
+        )
+
+        result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        data = json.loads(result)["data"]
+
+        assert data["activity_id"] == ACTIVITY_ID
+        assert len(data["buckets"]) == 4
+        assert data["total_time_seconds"] == 120 + 240 + 600 + 300
+        assert data["total_moving_time_seconds"] == 120 + 240 + 540 + 300
+
+    async def test_bucket_end_derived_from_next_start(self, mock_config, respx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/hr-histogram").mock(
+            return_value=Response(200, json=HR_BUCKETS)
+        )
+
+        result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        buckets = json.loads(result)["data"]["buckets"]
+
+        # Middle buckets: end == next bucket's start.
+        assert buckets[0]["hr_range"] == {"min_bpm": 60, "max_bpm": 65}
+        assert buckets[1]["hr_range"] == {"min_bpm": 65, "max_bpm": 70}
+        assert buckets[2]["hr_range"] == {"min_bpm": 70, "max_bpm": 75}
+        # Last bucket: width inferred from the first consecutive pair (5 bpm).
+        assert buckets[3]["hr_range"] == {"min_bpm": 75, "max_bpm": 80}
+
+    async def test_per_bucket_times_surface(self, mock_config, respx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/hr-histogram").mock(
+            return_value=Response(200, json=HR_BUCKETS)
+        )
+
+        result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        buckets = json.loads(result)["data"]["buckets"]
+
+        # The middle bucket had moving_secs < secs (some non-moving time).
+        assert buckets[2]["time_seconds"] == 600
+        assert buckets[2]["moving_time_seconds"] == 540
+
+    async def test_empty_payload_returns_empty_buckets(self, mock_config, respx_mock):
+        """Activity with no HR data — API returns [] (not {bins: []})."""
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/hr-histogram").mock(
+            return_value=Response(200, json=[])
+        )
+        respx_mock.get(f"/activity/{ACTIVITY_ID}").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": ACTIVITY_ID,
+                    "source": "MANUAL",
+                    "start_date_local": "2025-11-04T12:00:00",
+                },
+            )
+        )
+
+        result = await get_hr_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        data = json.loads(result)["data"]
+        assert data["buckets"] == []
+
+
+@pytest.mark.asyncio
+class TestPowerHistogram:
+    async def test_non_empty_payload_round_trips(self, mock_config, respx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/power-histogram").mock(
+            return_value=Response(200, json=POWER_BUCKETS)
+        )
+
+        result = await get_power_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        data = json.loads(result)["data"]
+
+        assert len(data["buckets"]) == 3
+        assert data["buckets"][0]["power_range"] == {"min_watts": 100, "max_watts": 150}
+        assert data["buckets"][1]["power_range"] == {"min_watts": 150, "max_watts": 200}
+        # Last bucket: width inferred (50 W).
+        assert data["buckets"][2]["power_range"] == {"min_watts": 200, "max_watts": 250}
+        assert data["total_time_seconds"] == 60 + 300 + 90
+
+
+@pytest.mark.asyncio
+class TestPaceAndGapHistograms:
+    async def test_pace_non_empty_payload_round_trips(self, mock_config, respx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        # Pace bucket `start` unit is API-defined; emit raw values without speculative formatting.
+        payload = [
+            {"start": 240, "secs": 100, "movingSecs": 100},
+            {"start": 270, "secs": 400, "movingSecs": 400},
+            {"start": 300, "secs": 150, "movingSecs": 150},
+        ]
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/pace-histogram").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_pace_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        buckets = json.loads(result)["data"]["buckets"]
+        assert buckets[0]["pace_range"] == {"start": 240, "end": 270}
+        assert buckets[2]["pace_range"] == {"start": 300, "end": 330}
+
+    async def test_gap_non_empty_payload_round_trips(self, mock_config, respx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=mock_config)
+
+        payload = [
+            {"start": 240, "secs": 200, "movingSecs": 200},
+            {"start": 270, "secs": 300, "movingSecs": 300},
+        ]
+        respx_mock.get(f"/activity/{ACTIVITY_ID}/gap-histogram").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_gap_histogram(activity_id=ACTIVITY_ID, ctx=ctx)
+        data = json.loads(result)["data"]
+        assert data["buckets"][0]["gap_range"] == {"start": 240, "end": 270}
+        assert "GAP" in data["note"]

--- a/tests/test_strava_limitation.py
+++ b/tests/test_strava_limitation.py
@@ -170,7 +170,7 @@ class TestAnalysisToolsStravaSurface:
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         respx_mock.get("/activity/16358453283/power-histogram").mock(
-            return_value=Response(200, json={"bins": []})
+            return_value=Response(200, json=[])
         )
         respx_mock.get("/activity/16358453283").mock(
             return_value=Response(200, json=STRAVA_STUB)
@@ -186,7 +186,7 @@ class TestAnalysisToolsStravaSurface:
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         respx_mock.get("/activity/16358453283/hr-histogram").mock(
-            return_value=Response(200, json={"bins": []})
+            return_value=Response(200, json=[])
         )
         respx_mock.get("/activity/16358453283").mock(
             return_value=Response(200, json=STRAVA_STUB)
@@ -202,7 +202,7 @@ class TestAnalysisToolsStravaSurface:
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         respx_mock.get("/activity/16358453283/pace-histogram").mock(
-            return_value=Response(200, json={"bins": []})
+            return_value=Response(200, json=[])
         )
         respx_mock.get("/activity/16358453283").mock(
             return_value=Response(200, json=STRAVA_STUB)
@@ -218,7 +218,7 @@ class TestAnalysisToolsStravaSurface:
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         respx_mock.get("/activity/16358453283/gap-histogram").mock(
-            return_value=Response(200, json={"bins": []})
+            return_value=Response(200, json=[])
         )
         respx_mock.get("/activity/16358453283").mock(
             return_value=Response(200, json=STRAVA_STUB)


### PR DESCRIPTION
## Summary

Fixes #39. The histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed on any activity with real data:

```
intervals_icu_mcp.models.Histogram() argument after ** must be a mapping, not list
```

Root cause: the `Histogram`/`HistogramBin` models were invented in the initial commit (2025-10-16) and never matched the actual API. The endpoints return a **bare JSON array** of buckets, not a wrapper object; each bucket carries `start`, `secs`, `movingSecs`, `watts`, `hr`, `cadence` — completely different from the fictional `min`/`max`/`count` shape. The bug was undetectable because the only tests mocked `{"bins": []}` (the invented shape), which short-circuited before deserialization ran against real data.

Closes #39

## Changes

- `models.py` — Replaced `HistogramBin` + `Histogram` with a single `Bucket` model matching the OpenAPI `Bucket` schema.
- `client.py` — All 4 `get_*_histogram` methods now return `list[Bucket]` parsed from the bare array, instead of `Histogram(**response.json())`.
- `tools/activity_analysis.py` — All 4 histogram tools iterate the list directly. Bucket end derived from the next bucket's `start`; for the final bucket, width is inferred from the first consecutive pair of starts and projected. Extracted a small `_bucket_end` helper shared across the 4 tools.
- `tests/test_strava_limitation.py` — Updated the 4 histogram Strava-stub mocks from `json={"bins": []}` → `json=[]` to match the real API shape.
- `tests/test_histogram_tools.py` (new) — End-to-end round-trip tests with **non-empty** bucket payloads for all 4 histograms. These tests would have caught the original bug; the previously-existing tests could not.
- `CHANGELOG.md` — Fix entry + breaking response-shape note under `[Unreleased]`.

## SemVer flag

**Breaking — response shape change.** Histogram tools now emit `buckets` (was `bins`), with `min_*`/`max_*` derived from consecutive starts plus `time_seconds` + `moving_time_seconds`. The old `count` field is dropped — the API returns time-in-bucket, not raw sample counts, so the previous `count` value was meaningless. Per `CLAUDE.md`, this requires a major version bump at the next release.

## Checklist

- [x] `make can-release` — same 8 pre-existing failures on `main` (default-mode tool count assertions in `test_transport_integration` and `test_delete_mode`); unrelated to this diff. 131/139 passing locally — added 7 new tests, broke none.
- [x] No API keys / credentials touched
- [x] Tool input shapes unchanged; only output shape changed (breaking — flagged above)
- [x] Manual verification against the real API: not performed (no test account), but the OpenAPI `Bucket` schema is what drove the new model.

## Test plan

- `uv run pytest tests/test_histogram_tools.py tests/test_strava_limitation.py -v` — 21/21 pass.
- Real-world verification once shipped: invoking `icu_get_hr_histogram` on any non-Strava run/ride should now return a `buckets` array with `hr_range`/`time_seconds`/`moving_time_seconds` per bucket, instead of erroring.