### PR TITLE
feat(response): gate fetched_at/query_type behind INTERVALS_ICU_DEBUG_METADATA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ INTERVALS_ICU_API_KEY=your_api_key_here
 
 # Your athlete ID (format: i123456, found in your profile URL)
 INTERVALS_ICU_ATHLETE_ID=i123456
+
+# Optional: include `fetched_at` + `query_type` in every response's metadata
+# block. Off by default to keep responses compact; enable for debugging.
+# INTERVALS_ICU_DEBUG_METADATA=false

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ exports/
 
 # Logs
 *.log
+
+# MCP local config
+.mcp.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> ⚠️ **Next release must be `v3.0.0`** — this section contains a response-shape breaking change (see `### Changed` below); per `CLAUDE.md`'s strict-SemVer rule, that requires a major bump.
+> ⚠️ **Next release must be `v3.0.0`** — this section contains response-shape breaking changes (see `### Changed` below); per `CLAUDE.md`'s strict-SemVer rule, that requires a major bump.
 
 ### Fixed
 - Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of `{min, max, secs}` objects, not a wrapper object; the previous `Histogram`/`HistogramBin` models never matched the actual API (the OpenAPI spec advertises a richer shape that isn't populated by these endpoints). Replaced with a minimal `Bucket` model and added regression tests with real-shape payloads.
 
 ### Changed
 - **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), each shaped `{<metric>_range: {min_*, max_*}, time_seconds}` where boundaries come straight from the API's `min`/`max` fields. The previous `count` field is dropped (the API doesn't return raw sample counts — `secs` is time-in-bucket).
+- **Breaking — response shape:** removed `fetched_at` and `query_type` from the auto-generated `metadata` block. The `metadata` key still exists on every response (tools still attach their own fields). Set `INTERVALS_ICU_DEBUG_METADATA=true` to restore the old behavior for debugging.
 
 ## [2.0.0] — 2026-04-29
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,11 +103,15 @@ async def tool_name(
             return ResponseBuilder.build_response(
                 data={"key": "value"},
                 analysis={"insights": "..."},
-                query_type="tool_type"
             )
     except ICUAPIError as e:
         return ResponseBuilder.build_error_response(e.message, error_type="api_error")
 ```
+
+By default, the `metadata` block only contains fields a tool explicitly attaches.
+Set `INTERVALS_ICU_DEBUG_METADATA=true` to additionally inject `fetched_at` and
+(if passed) `query_type` — useful for tracing but otherwise noise the LLM
+doesn't read.
 
 ## Error Handling
 

--- a/src/intervals_icu_mcp/response_builder.py
+++ b/src/intervals_icu_mcp/response_builder.py
@@ -6,13 +6,33 @@ across all MCP tools. All tools return JSON with a standard structure:
 {
     "data": {...},           # Main data payload
     "analysis": {...},       # Optional insights and computed metrics
-    "metadata": {...}        # Query metadata, timestamps, includes
+    "metadata": {...}        # Tool-supplied metadata (e.g. includes, scales)
 }
+
+By default `metadata` only contains fields that individual tools attach. Set
+`INTERVALS_ICU_DEBUG_METADATA=true` (or `1`/`yes`) in the environment to also
+inject `fetched_at` and `query_type` for debugging.
 """
 
+import functools
 import json
+import os
 from datetime import datetime
 from typing import Any, cast
+
+
+@functools.lru_cache(maxsize=1)
+def _debug_metadata_enabled() -> bool:
+    """Whether to include `fetched_at` / `query_type` in responses.
+
+    Read once at startup and cached. Truthy values: ``true``, ``1``, ``yes``
+    (case-insensitive).
+    """
+    return os.getenv("INTERVALS_ICU_DEBUG_METADATA", "").strip().lower() in {
+        "true",
+        "1",
+        "yes",
+    }
 
 
 def _convert_datetimes(obj: Any) -> Any:  # type: ignore[misc]
@@ -69,20 +89,21 @@ class ResponseBuilder:
         Args:
             data: Main data payload
             analysis: Optional analysis and insights
-            metadata: Optional metadata (will be enriched with timestamp)
-            query_type: Optional query type for metadata
+            metadata: Optional tool-supplied metadata
+            query_type: Optional query type label; only surfaced when
+                ``INTERVALS_ICU_DEBUG_METADATA`` is enabled.
 
         Returns:
             JSON string with structure:
             {
                 "data": {...},
                 "analysis": {...},
-                "metadata": {
-                    "fetched_at": "ISO timestamp",
-                    "query_type": "...",
-                    ...
-                }
+                "metadata": {...}
             }
+
+            With ``INTERVALS_ICU_DEBUG_METADATA=true``, metadata is also
+            enriched with ``fetched_at`` (ISO timestamp) and, if provided,
+            ``query_type``.
         """
         # Convert datetime objects to ISO strings
         converted_data = cast(dict[str, Any], _convert_datetimes(data))
@@ -95,12 +116,12 @@ class ResponseBuilder:
         if converted_analysis:
             response["analysis"] = converted_analysis
 
-        # Build metadata with timestamp
         meta = metadata or {}
         converted_meta = cast(dict[str, Any], _convert_datetimes(meta))
-        converted_meta["fetched_at"] = datetime.now().isoformat()
-        if query_type:
-            converted_meta["query_type"] = query_type
+        if _debug_metadata_enabled():
+            converted_meta["fetched_at"] = datetime.now().isoformat()
+            if query_type:
+                converted_meta["query_type"] = query_type
 
         response["metadata"] = converted_meta
 


### PR DESCRIPTION
## Summary

Closes #25.

Every tool response auto-injected `fetched_at` (ISO timestamp) and `query_type` (short string) into the `metadata` block — together ~70–87 chars per call. Neither was consumed by the LLM or surfaced to users; both were debug-style introspection that was never wired up to anything. Across a typical 10–15 tool-call conversation that's ~1,000–1,300 tokens of pure waste.

These fields are now omitted by default. Set `INTERVALS_ICU_DEBUG_METADATA=true` (also accepts `1`, `yes`) to restore them for debugging. The flag is read once at startup and cached.

The `metadata` key itself still always exists on every response — tools attach their own custom fields (`scales`, `includes`, etc.) and 28 tests rely on its presence. Only the auto-injected pair is gated.

## Changes

- `src/intervals_icu_mcp/response_builder.py` — add `_debug_metadata_enabled()` helper (cached `os.getenv` read); gate `fetched_at` + `query_type` writes in `build_response`. Module docstring updated.
- `.env.example` — document the new flag (commented out).
- `docs/architecture.md` — drop `query_type="tool_type"` from the canonical tool snippet; note the debug toggle.
- `CHANGELOG.md` — Unreleased entry under **Breaking — response shape**.

## SemVer

Response-shape change. Per CLAUDE.md this is SemVer-relevant — flagged as **breaking** in the changelog. Maintainer noted a major release is already coming for other reasons, so this rides along.

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright) — see Test plan note
- [x] New tools have a corresponding respx-mocked test file in `tests/` — N/A (no new tools)
- [x] Public-facing behavior changes are reflected in the README or `docs/` — `docs/architecture.md` + `.env.example` + CHANGELOG
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate — N/A
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

- `INTERVALS_ICU_DELETE_MODE=safe make can-release` → fully green (lint + pyright + 132 tests + coverage gate). The default `make can-release` shows 7 pre-existing failures locally caused by a developer `.env` further up the directory tree setting `DELETE_MODE=full`; CI has no such file and runs in safe mode.
- Manual round-trip against `build_response`:
  - Default: `{"data":{"k":"v"},"metadata":{"custom":1}}` — no `fetched_at`/`query_type`.
  - `INTERVALS_ICU_DEBUG_METADATA=true`: `metadata` contains `custom`, `fetched_at`, `query_type` — tool-supplied fields preserved alongside the debug pair.
- No test files modified; no tool modules modified. The 48 `query_type=` callsites become no-ops by default and re-engage under debug mode.