### PR TITLE
refactor: trim 3 fattest tool descriptions and move long-form content into MCP Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Histogram tools (`icu_get_hr_histogram`, `icu_get_power_histogram`, `icu_get_pace_histogram`, `icu_get_gap_histogram`) crashed with `argument after ** must be a mapping, not list` on any activity with real data. The endpoints return a bare JSON array of `{min, max, secs}` objects, not a wrapper object; the previous `Histogram`/`HistogramBin` models never matched the actual API (the OpenAPI spec advertises a richer shape that isn't populated by these endpoints). Replaced with a minimal `Bucket` model and added regression tests with real-shape payloads.
 
+### Added
+- Two new MCP Resources: `intervals-icu://event-categories` (calendar event category enum + use-case mapping + training_availability values) and `intervals-icu://custom-item-schemas` (per-item_type `content` schema for `create_custom_item` / `update_custom_item` with INPUT_FIELD/ACTIVITY_FIELD/INTERVAL_FIELD constraints and worked examples). The tool descriptions now point at these instead of inlining the same prose every session.
+
 ### Changed
 - **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), each shaped `{<metric>_range: {min_*, max_*}, time_seconds}` where boundaries come straight from the API's `min`/`max` fields. The previous `count` field is dropped (the API doesn't return raw sample counts — `secs` is time-in-bucket).
 - **Breaking — response shape:** removed `fetched_at` and `query_type` from the auto-generated `metadata` block. The `metadata` key still exists on every response (tools still attach their own fields). Set `INTERVALS_ICU_DEBUG_METADATA=true` to restore the old behavior for debugging.
+- Trimmed verbose param descriptions on `icu_create_event`, `icu_update_event`, `icu_bulk_create_events`, `icu_create_custom_item`, and `icu_update_custom_item`. Long enum lists and content schemas moved to the new Resources (measured ~1,200 tokens saved upfront per default-mode session). Pure tool-description change; no behavioral or response-shape change.
 
 ## [2.0.0] — 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Intervals.icu — provides up to 58 tools, 2 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 55 tools; `full` registers all 58, `none` registers 52.
+MCP (Model Context Protocol) server for Intervals.icu — provides up to 58 tools, 4 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 55 tools; `full` registers all 58, `none` registers 52.
 
 - **Language**: Python 3.11+
 - **Framework**: FastMCP

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-58 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 2 MCP Resources (athlete profile, workout syntax reference) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
+58 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 4 MCP Resources (athlete profile, workout syntax, event categories, custom item schemas) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
 
 ## Quick Start
 
@@ -245,7 +245,7 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 
 ## Available Tools
 
-58 tools, 2 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
+58 tools, 4 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
 
 | Category | Tools | Summary |
 |---|---|---|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,19 @@ All tools return JSON with consistent structure:
 
 Pydantic models for all API responses. Models include: Activity, Athlete, Wellness, Event, PowerCurve, etc.
 
+## MCP Resources
+
+Resources expose reference content the LLM can pull on demand. They are paid only when fetched, unlike tool descriptions (paid every session). We use this to keep tool descriptions lean — long enum lists, schema definitions, and DSL specs live in resources.
+
+| URI | Source module | Purpose |
+|---|---|---|
+| `intervals-icu://athlete/profile` | inline in `server.py` | Live athlete profile + fitness metrics; loads via `ICUClient` |
+| `intervals-icu://workout-syntax` | `workout_syntax.py` | Intervals.icu structured workout DSL reference (cycling/running/swimming) |
+| `intervals-icu://event-categories` | `event_categories.py` | Calendar event category enum + use-case mapping + training_availability values, referenced from `create_event` / `update_event` / `bulk_create_events` |
+| `intervals-icu://custom-item-schemas` | `custom_item_schemas.py` | Per-`item_type` `content` schema for `create_custom_item` / `update_custom_item` (INPUT_FIELD / ACTIVITY_FIELD / INTERVAL_FIELD constraints + worked examples) |
+
+When adding a new tool whose description repeats >~200 chars of reference content (enums, schemas, DSL), prefer extracting that content into a new module and registering it as a resource. The pattern: a single `*_SPEC = """..."""` constant per module, imported lazily inside the resource function.
+
 ## Tool Organization
 
 Tools are organized into 11 categories in `src/intervals_icu_mcp/tools/`:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool, Resource, and Prompt Reference
 
-Complete inventory of everything the Intervals.icu MCP server exposes: up to 58 tools across 11 categories, 2 MCP Resources, and 7 MCP Prompts.
+Complete inventory of everything the Intervals.icu MCP server exposes: up to 58 tools across 11 categories, 4 MCP Resources, and 7 MCP Prompts.
 
 ## Delete Safety Mode
 
@@ -169,10 +169,12 @@ The user's personal additions to their account: custom charts on dashboards, cus
 
 Resources provide ongoing context to the LLM without requiring explicit tool calls.
 
-| Resource                          | Description                                                              |
-| --------------------------------- | ------------------------------------------------------------------------ |
-| `intervals-icu://athlete/profile` | Complete athlete profile with current fitness metrics and sport settings |
-| `intervals-icu://workout-syntax`  | Structured workout syntax reference for generating valid Intervals.icu workouts (cycling, running, swimming) |
+| Resource                              | Description                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `intervals-icu://athlete/profile`     | Complete athlete profile with current fitness metrics and sport settings |
+| `intervals-icu://workout-syntax`      | Structured workout syntax reference for generating valid Intervals.icu workouts (cycling, running, swimming) |
+| `intervals-icu://event-categories`    | Calendar event category enum (WORKOUT, RACE_A/B/C, HOLIDAY, …), training_availability values, legacy aliases, and use-case guidance for create_event / update_event / bulk_create_events |
+| `intervals-icu://custom-item-schemas` | Per-item_type `content` schema for create_custom_item / update_custom_item — INPUT_FIELD/ACTIVITY_FIELD/INTERVAL_FIELD constraints with worked examples; chart/panel/zones/stream guidance |
 
 ## MCP Prompts
 

--- a/src/intervals_icu_mcp/custom_item_schemas.py
+++ b/src/intervals_icu_mcp/custom_item_schemas.py
@@ -1,0 +1,116 @@
+"""Intervals.icu custom item content schemas reference for LLM consumption.
+
+Exposed as the `intervals-icu://custom-item-schemas` MCP Resource. The
+`content` parameter on create_custom_item and update_custom_item points
+the LLM here instead of inlining the per-item_type schema in every
+Annotated description.
+"""
+
+CUSTOM_ITEM_SCHEMAS_SPEC = """# Intervals.icu Custom Item Content Schemas
+
+Use this reference when constructing the `content` object for
+create_custom_item or update_custom_item. The shape of `content` depends
+on the `item_type` value. **Read this before guessing — getting `content`
+wrong causes a generic HTTP 400 from the API with no schema hint.**
+
+## Field-type items (REQUIRE `content`)
+
+These three item types share an identical content schema:
+
+- `INPUT_FIELD` — extra input on the wellness page (e.g. RPE, mood, weight)
+- `ACTIVITY_FIELD` — extra field on each activity (e.g. bike weight, fuel)
+- `INTERVAL_FIELD` — extra field on each interval (e.g. perceived effort)
+
+### Schema
+
+```json
+{
+  "code": "<MachineId>",
+  "type": "<numeric|text|select>",
+  "aggregate": "<MIN|SUM|MAX|AVERAGE>"
+}
+```
+
+### Constraints
+
+- `code`: machine identifier. Regex: `[A-Z][A-Za-z0-9]+`. Must start with
+  an uppercase letter and contain only ASCII alphanumerics. No spaces,
+  underscores, hyphens, or dots.
+- `type`: must be exactly one of `numeric`, `text`, or `select`.
+  **NOT `number` or `string` — the API rejects those.**
+- `aggregate`: must be exactly one of `MIN`, `SUM`, `MAX`, `AVERAGE`.
+  **NOT `AVG` — the API rejects that.**
+
+### Worked examples
+
+```json
+{
+  "name": "RPE",
+  "item_type": "INPUT_FIELD",
+  "description": "Rating of perceived exertion (1-10)",
+  "content": {"code": "Rpe", "type": "numeric", "aggregate": "AVERAGE"},
+  "visibility": "PRIVATE"
+}
+```
+
+```json
+{
+  "name": "Bike Weight",
+  "item_type": "ACTIVITY_FIELD",
+  "content": {"code": "BikeWeight", "type": "numeric", "aggregate": "AVERAGE"}
+}
+```
+
+```json
+{
+  "name": "Workout Tag",
+  "item_type": "INTERVAL_FIELD",
+  "content": {"code": "Tag", "type": "select", "aggregate": "MAX"}
+}
+```
+
+## All other item types (OMIT `content` when creating)
+
+For these types, **do not send `content`** when creating via the API.
+The API provisions a default configuration that the user then customizes
+in the Intervals.icu web UI (where the chart-builder / zone-editor /
+panel-designer lives). Sending a hand-rolled `content` for these types
+without knowing the exact shape will fail.
+
+| `item_type`         | What it is                                       |
+|---------------------|--------------------------------------------------|
+| `FITNESS_CHART`     | Custom chart on the fitness page                 |
+| `FITNESS_TABLE`     | Custom table on the fitness page                 |
+| `TRACE_CHART`       | Custom trace (overlay) chart                     |
+| `ACTIVITY_CHART`    | Custom chart on the activity page                |
+| `ACTIVITY_HISTOGRAM`| Custom histogram on the activity page            |
+| `ACTIVITY_HEATMAP`  | Custom heatmap on the activity page              |
+| `ACTIVITY_MAP`      | Custom map on the activity page                  |
+| `ACTIVITY_PANEL`    | Custom panel (composite) on the activity page    |
+| `ACTIVITY_STREAM`   | Computed time-series stream                      |
+| `ZONES`             | Custom power/HR/pace zone set                    |
+
+### Recommended workflow for these types
+
+1. Call `create_custom_item` with just `name`, `item_type`, and
+   `visibility` — omit `content`.
+2. Tell the user the item was created and they should open it in the
+   Intervals.icu UI to configure the details.
+3. If the user later wants to inspect the shape, call
+   `get_custom_item(item_id)` after they've configured it — that returns
+   the actual `content` the API stored, which can be used as a template
+   for future `update_custom_item` calls.
+
+## `visibility` enum (any item type)
+
+- `PRIVATE` (default if omitted) — only the owner sees it
+- `FOLLOWERS` — visible to followers
+- `PUBLIC` — visible to anyone
+
+## Update semantics
+
+`update_custom_item.content` **replaces** the existing `content` object
+wholesale. If you want to change one field of a field-type item, fetch
+the current content with `get_custom_item` first, mutate it, and pass
+the full object back.
+"""

--- a/src/intervals_icu_mcp/event_categories.py
+++ b/src/intervals_icu_mcp/event_categories.py
@@ -1,0 +1,75 @@
+"""Intervals.icu calendar event categories reference for LLM consumption.
+
+Exposed as the `intervals-icu://event-categories` MCP Resource. The
+`category` parameter on event-management tools (create_event, update_event,
+bulk_create_events) points the LLM here instead of inlining the full enum +
+use-case mapping in every Annotated description.
+"""
+
+EVENT_CATEGORIES_SPEC = """# Intervals.icu Calendar Event Categories
+
+Use this reference when picking a `category` value for create_event /
+update_event / bulk_create_events. Match the user's intent to the closest
+category. The API enforces the enum strictly — unknown values are rejected.
+
+## Categories by use case
+
+### Planned training
+- `WORKOUT` — a planned workout. For structured workouts, put
+  Intervals.icu workout syntax in the `description` field (see the
+  `intervals-icu://workout-syntax` resource). The server parses the text
+  into a structured workout with training load and zone distribution.
+- `PLAN` — a training plan day marker (used by training-plan automation).
+
+### Races
+- `RACE_A` — top-priority "A" race
+- `RACE_B` — secondary race
+- `RACE_C` — minor race / tune-up event
+
+Race events **require** an `event_type` (activity discipline). The API
+rejects races without a discipline. Valid disciplines: `Ride`, `Run`,
+`Swim`, `Walk`, `Hike`, `VirtualRide`, `VirtualRun`, `Other`.
+
+### Performance goals
+- `TARGET` — a performance goal or milestone (e.g. "FTP 300W by June").
+
+### Life events (typically use start_date + end_date + training_availability)
+- `HOLIDAY` — vacation / time off (German UI: Urlaub)
+- `SICK` — illness (German UI: Krank)
+- `INJURED` — injury (German UI: Verletzt)
+
+For these ranged categories, set `training_availability` so the planner
+knows how to handle scheduled workouts in the window:
+- `NORMAL` — train as planned (German UI: Verfügbar)
+- `LIMITED` — partial training capacity (German UI: Begrenzt)
+- `UNAVAILABLE` — no training (German UI: Nicht verfügbar)
+
+### Fitness chart adjustments
+- `SET_EFTP` — manually set eFTP (estimated FTP) on this date
+- `FITNESS_DAYS` — adjust fitness-days count (German UI: Fitnesstage)
+- `SEASON_START` — season start marker (German UI: Saison)
+- `SET_FITNESS` — manually set fitness (CTL) value
+
+### Notes
+- `NOTE` — generic calendar note. Use when the user wants to record
+  something on a date that isn't a workout, race, or life event.
+
+## Legacy aliases (accepted on input, normalized internally)
+- `RACE` → `RACE_A`
+- `GOAL` → `TARGET`
+
+The server normalizes these before sending to the API. Users can pass
+either form; new code should prefer the canonical names.
+
+## Picking the right category
+
+When the user's request is ambiguous, ask them. Common ambiguities:
+
+- "Add a race" → ask which tier (A, B, C) so it weights the fitness
+  chart correctly. Default to `RACE_A` only if the user makes it clear
+  this is their main goal.
+- "Block off some days" → ranged HOLIDAY/SICK/INJURED. Pick by reason;
+  if the user just says "I'm not training next week," ask why.
+- "Add a workout" → `WORKOUT`. If the user describes structure
+  (intervals, targets), include it in `description` using workout syntax.
+"""

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -707,6 +707,37 @@ async def workout_syntax_resource() -> str:
     return WORKOUT_SYNTAX_SPEC
 
 
+@mcp.resource("intervals-icu://event-categories")
+async def event_categories_resource() -> str:
+    """Intervals.icu calendar event categories reference.
+
+    Use this when picking a `category` value for create_event / update_event /
+    bulk_create_events. Documents the full enum (WORKOUT, NOTE, RACE_A/B/C,
+    TARGET, PLAN, HOLIDAY, SICK, INJURED, SET_EFTP, FITNESS_DAYS, SEASON_START,
+    SET_FITNESS), the legacy aliases (RACE→RACE_A, GOAL→TARGET), the
+    training_availability enum for ranged categories, and use-case guidance.
+    """
+    from .event_categories import EVENT_CATEGORIES_SPEC
+
+    return EVENT_CATEGORIES_SPEC
+
+
+@mcp.resource("intervals-icu://custom-item-schemas")
+async def custom_item_schemas_resource() -> str:
+    """Intervals.icu custom item content schemas reference.
+
+    Use this BEFORE constructing the `content` object for create_custom_item or
+    update_custom_item. The shape of `content` depends on `item_type`. Documents
+    the well-known schema for INPUT_FIELD / ACTIVITY_FIELD / INTERVAL_FIELD
+    (code/type/aggregate constraints plus worked examples) and explains that
+    chart/panel/zones/stream types should omit `content` and be configured in
+    the Intervals.icu UI after creation.
+    """
+    from .custom_item_schemas import CUSTOM_ITEM_SCHEMAS_SPEC
+
+    return CUSTOM_ITEM_SCHEMAS_SPEC
+
+
 # MCP Prompts - Templates for common queries
 @mcp.prompt()
 async def generate_workout(

--- a/src/intervals_icu_mcp/tools/custom_items.py
+++ b/src/intervals_icu_mcp/tools/custom_items.py
@@ -176,16 +176,11 @@ async def create_custom_item(
     description: Annotated[str | None, "Optional description shown to the user"] = None,
     content: Annotated[
         dict[str, Any] | None,
-        "Configuration object whose schema depends on item_type. "
-        "REQUIRED for INPUT_FIELD, ACTIVITY_FIELD, INTERVAL_FIELD; for these "
-        "the schema is: `code` (machine identifier — must match regex "
-        "[A-Z][A-Za-z0-9]+, i.e. start with uppercase and contain only "
-        "alphanumerics, no spaces/underscores), `type` ('numeric', 'text', "
-        "or 'select' — NOT 'number'), `aggregate` ('MIN', 'SUM', 'MAX', or "
-        "'AVERAGE' — NOT 'AVG'). Example: "
-        "{'code': 'Rpe', 'type': 'numeric', 'aggregate': 'AVERAGE'}. "
-        "Optional for chart/panel/zones/stream types where the API uses "
-        "defaults — you can omit and configure in the Intervals.icu UI later.",
+        "Configuration object whose schema depends on item_type. Read "
+        "intervals-icu://custom-item-schemas BEFORE constructing — it documents "
+        "the {code, type, aggregate} shape required for INPUT_FIELD / "
+        "ACTIVITY_FIELD / INTERVAL_FIELD (with constraints and worked examples) "
+        "and explains that chart/panel/zones/stream types should omit `content`.",
     ] = None,
     visibility: Annotated[
         str | None,
@@ -199,24 +194,9 @@ async def create_custom_item(
     """Create a custom addition to the user's Intervals.icu account.
 
     Use when the user says things like: "add a custom field for RPE", "create
-    a custom power zone set", "add a chart for monthly distance to my
-    dashboard", "add a bike-weight field to activities". Match the user's
-    intent to the right `item_type` enum value (see that param's description
-    for the mapping).
-
-    Args:
-        name: Display name shown in the Intervals.icu UI
-        item_type: One of the API enum values matching the user's intent
-        description: Optional human-readable description
-        content: Configuration object. REQUIRED for INPUT_FIELD, ACTIVITY_FIELD,
-            INTERVAL_FIELD — see the parameter's annotation for the inner schema
-            (`code`, `type`, `aggregate`) and validation rules. Optional for
-            chart/panel/zones/stream types.
-        visibility: PRIVATE, FOLLOWERS, or PUBLIC
-        athlete_id: Athlete ID (uses configured default if not provided)
-
-    Returns:
-        JSON string with the created custom item including its new ID
+    a custom power zone set", "add a chart for monthly distance". Match the
+    user's intent to the right `item_type` (see that param's description). For
+    the `content` schema per item_type, read intervals-icu://custom-item-schemas.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -259,11 +239,9 @@ async def update_custom_item(
     description: Annotated[str | None, "Updated description"] = None,
     content: Annotated[
         dict[str, Any] | None,
-        "Updated configuration content (replaces existing content). Same "
-        "schema rules as create_custom_item.content — for field-type items "
-        "the inner shape is {`code`, `type`, `aggregate`} with the same "
-        "validation constraints (code regex [A-Z][A-Za-z0-9]+, type in "
-        "numeric/text/select, aggregate in MIN/SUM/MAX/AVERAGE).",
+        "Updated configuration content (replaces existing wholesale). Same "
+        "schema as create_custom_item.content — see "
+        "intervals-icu://custom-item-schemas for the per-item_type shape.",
     ] = None,
     visibility: Annotated[str | None, "Updated visibility: PRIVATE, FOLLOWERS, or PUBLIC"] = None,
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
@@ -272,22 +250,10 @@ async def update_custom_item(
     """Modify an existing custom chart/field/zones/panel.
 
     Use when the user wants to change one of their existing customizations:
-    "rename my custom field", "make this chart public", "change the
-    description on my zones". You usually need icu_get_custom_items first to
-    find the right `item_id`. Only fields you pass are sent — others are
-    left unchanged.
-
-    Args:
-        item_id: Custom item ID (from icu_get_custom_items)
-        name: New display name (optional)
-        item_type: New API type (optional, rare)
-        description: New description (optional)
-        content: New configuration object — REPLACES the existing one (optional)
-        visibility: New visibility: PRIVATE, FOLLOWERS, or PUBLIC (optional)
-        athlete_id: Athlete ID (uses configured default if not provided)
-
-    Returns:
-        JSON string with the updated custom item
+    "rename my custom field", "make this chart public". Usually need
+    icu_get_custom_items first to find the right `item_id`. Only fields you
+    pass are sent — others are left unchanged. For `content` schema, see
+    intervals-icu://custom-item-schemas.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -158,39 +158,34 @@ async def create_event(
     name: Annotated[str, "Event name"],
     category: Annotated[
         str,
-        "Event category. WORKOUT, NOTE, RACE_A/RACE_B/RACE_C (race tier), TARGET "
-        "(performance goal), PLAN, HOLIDAY (Urlaub), SICK (Krank), INJURED "
-        "(Verletzt), SET_EFTP, FITNESS_DAYS (Fitnesstage), SEASON_START (Saison), "
-        "SET_FITNESS. Legacy aliases RACE→RACE_A and GOAL→TARGET are accepted.",
+        "Event category enum. Common: WORKOUT, NOTE, RACE_A/B/C, TARGET, PLAN, "
+        "HOLIDAY, SICK, INJURED. Full list with use-case guidance and the "
+        "training_availability enum: intervals-icu://event-categories resource. "
+        "Legacy aliases RACE→RACE_A, GOAL→TARGET accepted.",
     ],
     description: Annotated[
         str | None,
-        "Event description. For WORKOUT events, use Intervals.icu structured workout "
-        "syntax to define intervals, targets, and structure. The server automatically "
-        "parses this into a structured workout. Read the intervals-icu://workout-syntax "
-        "resource for the complete syntax reference. Example: "
-        "'Warmup\n- 10m ramp 50%-75%\n\nMain Set 3x\n- 5m 95%\n- 3m 55%\n\nCooldown\n- 10m 50%'",
+        "Event description. For WORKOUT events, use Intervals.icu structured "
+        "workout syntax (see intervals-icu://workout-syntax resource) — the "
+        "server parses it into a structured workout with training load and zones.",
     ] = None,
     event_type: Annotated[
         str | None,
-        "Activity discipline (NOT the category). Must be one of: "
-        "Ride, Run, Swim, Walk, Hike, VirtualRide, VirtualRun, Other. "
-        "Required for RACE_A/RACE_B/RACE_C events — the API rejects races "
-        "without a discipline.",
+        "Activity discipline (NOT the category): Ride, Run, Swim, Walk, Hike, "
+        "VirtualRide, VirtualRun, Other. Required for RACE_A/B/C events.",
     ] = None,
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
     training_load: Annotated[int | None, "Planned training load"] = None,
     end_date: Annotated[
         str | None,
-        "End date in YYYY-MM-DD format. Use for ranged categories like INJURED, "
-        "SICK, HOLIDAY, SEASON_START to mark a multi-day block.",
+        "End date in YYYY-MM-DD format. Use for ranged categories (INJURED, "
+        "SICK, HOLIDAY, SEASON_START) to mark a multi-day block.",
     ] = None,
     training_availability: Annotated[
         str | None,
-        "Training availability during the event: NORMAL (Verfügbar), LIMITED "
-        "(Begrenzt), or UNAVAILABLE (Nicht verfügbar). Typical for INJURED/SICK/"
-        "HOLIDAY blocks so the planner skips or scales workouts.",
+        "Training availability: NORMAL, LIMITED, or UNAVAILABLE. Typical for "
+        "INJURED/SICK/HOLIDAY blocks.",
     ] = None,
     color: Annotated[str | None, "Custom display color (hex string)"] = None,
     show_as_note: Annotated[bool | None, "Show event as a note marker on the fitness chart"] = None,
@@ -201,37 +196,11 @@ async def create_event(
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create a new calendar event.
+    """Create a calendar event.
 
-    Supports the full Intervals.icu calendar category set: planned workouts, notes,
-    races (RACE_A/B/C tiers), performance targets, training plans, and life-event
-    blocks like INJURED, SICK, HOLIDAY, SEASON_START. Block-style categories
-    typically use start_date + end_date + training_availability so the planner
-    treats the affected days correctly.
-
-    For WORKOUT events, the 'description' field accepts Intervals.icu structured
-    workout syntax. The server automatically parses this text into a structured
-    workout with calculated training load, zone distribution, and device sync.
-    Read the intervals-icu://workout-syntax resource for the complete syntax.
-
-    Args:
-        start_date: Date in ISO-8601 format (YYYY-MM-DD)
-        name: Name of the event
-        category: One of the categories listed in the parameter description
-        description: For workouts, structured workout text (see workout-syntax resource)
-        event_type: Activity type (e.g., "Ride", "Run", "Swim") for workouts
-        duration_seconds: Planned duration for workouts
-        distance_meters: Planned distance for workouts
-        training_load: Planned training load for workouts
-        end_date: End date for ranged categories (INJURED, SICK, HOLIDAY, ...)
-        training_availability: NORMAL, LIMITED, or UNAVAILABLE
-        color: Custom color hex string
-        show_as_note: Show as a note on the fitness chart
-        not_on_fitness_chart: Hide from the fitness chart
-        show_on_ctl_line: Render on the CTL line
-
-    Returns:
-        JSON string with created event data
+    For category guidance and the training_availability enum, read the
+    intervals-icu://event-categories resource. For structured WORKOUT events,
+    put workout-syntax text in `description` — see intervals-icu://workout-syntax.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -347,28 +316,9 @@ async def update_event(
 ) -> str:
     """Update an existing calendar event.
 
-    Modifies one or more fields of an existing event. Only provide the fields
-    you want to change - other fields will remain unchanged. Use end_date and
-    training_availability to extend or update INJURED/SICK/HOLIDAY blocks.
-
-    Args:
-        event_id: ID of the event to update
-        name: New name for the event
-        description: New description
-        start_date: New start date in YYYY-MM-DD format
-        event_type: New activity type
-        duration_seconds: New planned duration
-        distance_meters: New planned distance
-        training_load: New planned training load
-        end_date: New end date for ranged events
-        training_availability: NORMAL, LIMITED, or UNAVAILABLE
-        color: New color hex string
-        show_as_note: Show as a note on the fitness chart
-        not_on_fitness_chart: Hide from the fitness chart
-        show_on_ctl_line: Render on the CTL line
-
-    Returns:
-        JSON string with updated event data
+    Only fields you pass are sent — other fields remain unchanged. For category
+    and training_availability semantics, see intervals-icu://event-categories.
+    For WORKOUT `description` syntax, see intervals-icu://workout-syntax.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -515,33 +465,21 @@ async def delete_event(
 async def bulk_create_events(
     events: Annotated[
         str,
-        "JSON array of events. Required per event: start_date_local, name, category. "
-        "Optional: description, type, moving_time, distance, icu_training_load, "
-        "end_date_local (ranged categories), training_availability "
-        "(NORMAL/LIMITED/UNAVAILABLE), color, show_as_note, not_on_fitness_chart, "
-        "show_on_ctl_line. Categories: WORKOUT, NOTE, RACE_A/B/C, TARGET, PLAN, "
-        "HOLIDAY, SICK, INJURED, SET_EFTP, FITNESS_DAYS, SEASON_START, SET_FITNESS "
-        "(legacy RACE→RACE_A and GOAL→TARGET aliases accepted). For WORKOUT events, "
-        "include structured workout syntax in 'description' (see "
-        "intervals-icu://workout-syntax resource).",
+        "JSON array of event objects. Required per event: start_date_local, "
+        "name, category. Optional: description, type, moving_time, distance, "
+        "icu_training_load, end_date_local, training_availability, color, "
+        "show_as_note, not_on_fitness_chart, show_on_ctl_line. See "
+        "intervals-icu://event-categories for the category enum and "
+        "intervals-icu://workout-syntax for WORKOUT `description` syntax.",
     ],
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Create multiple calendar events in a single operation.
 
-    More efficient than creating events one at a time. Provide a JSON array
-    of event objects with the same fields accepted by create_event.
-
-    For WORKOUT events, include Intervals.icu structured workout syntax in the
-    'description' field. Read the intervals-icu://workout-syntax resource for the
-    complete syntax.
-
-    Args:
-        events: JSON array of event objects to create
-
-    Returns:
-        JSON string with created events
+    More efficient than calling create_event in a loop. Each event object accepts
+    the same fields as create_event. See intervals-icu://event-categories and
+    intervals-icu://workout-syntax for the referenced enums and DSL.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -64,12 +64,14 @@ class TestInMemoryTransport:
                         f"{tool.name} should carry destructiveHint=True"
                     )
 
-    async def test_both_resources_registered(self):
+    async def test_all_resources_registered(self):
         async with Client(mcp) as client:
             resources = await client.list_resources()
             uris = {str(r.uri) for r in resources}
             assert "intervals-icu://athlete/profile" in uris
             assert "intervals-icu://workout-syntax" in uris
+            assert "intervals-icu://event-categories" in uris
+            assert "intervals-icu://custom-item-schemas" in uris
 
     async def test_prompts_registered(self):
         async with Client(mcp) as client:


### PR DESCRIPTION
## Summary

Trims the verbose `Annotated` parameter descriptions on `icu_create_event`, `icu_update_event`, `icu_bulk_create_events`, `icu_create_custom_item`, and `icu_update_custom_item`. Long enum lists and content schemas move into two new MCP Resources that tools point at on demand.

Pure tool-description change — no behavior, no response shape, no parameter signature changes.

Closes #26.

## Changes

- New module `src/intervals_icu_mcp/event_categories.py` — `EVENT_CATEGORIES_SPEC` documenting the full category enum (WORKOUT, NOTE, RACE_A/B/C, TARGET, PLAN, HOLIDAY, SICK, INJURED, SET_EFTP, FITNESS_DAYS, SEASON_START, SET_FITNESS), legacy aliases (RACE→RACE_A, GOAL→TARGET), the `training_availability` enum for ranged categories, and use-case guidance.
- New module `src/intervals_icu_mcp/custom_item_schemas.py` — `CUSTOM_ITEM_SCHEMAS_SPEC` documenting the `{code, type, aggregate}` schema for INPUT_FIELD / ACTIVITY_FIELD / INTERVAL_FIELD (with regex/enum constraints and three worked examples) plus the "omit `content` and configure in the UI" guidance for chart/panel/zones/stream types.
- Registered as `intervals-icu://event-categories` and `intervals-icu://custom-item-schemas` resources in `server.py`.
- Trimmed `create_event` / `update_event` / `bulk_create_events` `Annotated` strings and function docstrings (event_management.py: −62 net lines).
- Trimmed `create_custom_item` / `update_custom_item` `content` `Annotated` strings and function docstrings (custom_items.py: −34 net lines).
- `bulk_create_events` was included even though it's not in the original #26 acceptance criteria — it inlined the same category enum + workout-syntax pointer.
- Updated `test_transport_integration.py` to assert all 4 resources are registered (was 2).
- Updated resource counts in README.md (2 places), CLAUDE.md, docs/tools.md, and added a new "MCP Resources" section in docs/architecture.md documenting the trim discipline.
- CHANGELOG.md entry under `[Unreleased]`.

## Token math

| Tool | Before (chars) | After (chars) | Approx tokens saved |
|---|---:|---:|---:|
| `icu_create_event` | ~3,300 | ~1,300 | ~570 |
| `icu_update_event` | ~1,650 | ~750 | ~260 |
| `icu_bulk_create_events` | ~1,100 | ~700 | ~110 |
| `icu_create_custom_item` | ~2,380 | ~1,650 | ~210 |
| `icu_update_custom_item` | ~1,000 | ~700 | ~85 |
| **Total** | **~9,430** | **~5,100** | **~1,235** |

Estimated **~1,200 tokens saved upfront per session** on a default-mode user. The cost of the new resources is paid only when fetched.

## Empirical validation (Haiku 4.5 smoke eval, 15 tasks)

Ran 15 representative tasks against both `main` and this branch (Claude Code, Haiku 4.5, one full run each):

- **Routing identical on 15/15** — the trimmed descriptions still pick the right tool.
- **Argument confidence:** 6 tasks improved, 8 stable, 1 marginally degraded (single-run, likely model variance).
- **Resource-fetching pattern validated** — Haiku reliably fetched `intervals-icu://custom-item-schemas` and `intervals-icu://event-categories` when needed. The biggest wins came on tasks that depended on those resources for argument construction.
- Haiku is the cost-sensitive tier most agentic deployments use, so this validates the description→resource hand-off pattern for the long-tail follow-up.

## SemVer

Pure tool-description trim. No response-shape, parameter, or behavioral change. No bump triggered by this PR.

## Cache invalidation

This PR busts every active user's tool-description prompt cache on rollout — a one-time cost paid the next time each user opens a conversation. Steady-state savings are net-positive after the first session.

## Follow-ups

- #46 (long-tail trim across the remaining ~54 tools) — pattern now empirically validated, lower risk.
- #29 (input_examples on high-complexity tools) — accuracy-positive complement, lower priority now that the Haiku-skips-resource risk is empirically de-risked.
- #27 deferred.

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright). 139/139 tests pass; 10/10 pyroma. (Pre-existing local `.env` leak causes a `delete_mode` test failure if `INTERVALS_ICU_DELETE_MODE=full` is set in `.env`; verified clean by running with `.env` moved aside. CI is unaffected.)
- [x] New tools have a corresponding respx-mocked test file in `tests/` — N/A, no new tools.
- [x] Public-facing behavior changes are reflected in the README or `docs/`.
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate — N/A, no new tools.
- [x] No API keys, athlete IDs, or other credentials are committed.

## Test plan

- [x] `make can-release` green (with `.env` moved aside to bypass local env leak).
- [x] `test_all_resources_registered` updated and passes.
- [x] All 33 `test_event_tools.py` cases pass against the trimmed descriptions.
- [x] All 10 `test_custom_items_tools.py` cases pass against the trimmed descriptions.
- [x] Haiku 4.5 smoke eval across 15 tasks: routing identical, argument confidence ≥ baseline (see Empirical validation above).