### PR TITLE
refactor(tools): rewrite first-sentences on 9 confusable tools for clearer LLM routing

### DIFF
--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -213,13 +213,21 @@ These are *targets*, not hard caps. Going over with good reason is fine — but 
 
 ### Confusable-name discipline
 
-If your tool name shares a prefix, suffix, or noun with another tool, the opening sentence MUST disambiguate. Existing confusable clusters to watch:
+If your tool name shares a prefix, suffix, or noun with another tool, the opening sentence MUST disambiguate. Anthropic identifies tool-name similarity as the *top cause* of LLM tool-selection failures — descriptions are the only thing standing between the LLM and a wrong-tool round-trip.
 
-- `icu_get_activity_*` family (details / intervals / streams)
-- `icu_search_activities` vs `icu_search_activities_full`
-- `icu_create_event` / `icu_bulk_create_events` / `icu_duplicate_events`
-- `icu_get_*_curves` / `icu_get_*_histogram` (per metric)
-- `icu_*_message` vs `icu_*_messages` (singular = write, plural = read)
+**Technique (per PR #30):**
+1. **Lead the first sentence with the distinguishing access pattern**, not the shared concept. NOT *"Get details about an activity."* → DO *"Fetch the headline SUMMARY of one activity — name, sport, date, distance, training load, weather."*
+2. **Use ALL-CAPS sparingly on the disambiguator word** (ONE / MANY / SUMMARY / RANGE / LIGHT / FULL / RAW / COPY). One word per first sentence. It anchors the LLM's attention to the choice axis.
+3. **Cross-reference siblings explicitly in the body** — name them and say when to pick each. The LLM evaluates tools partly by what their siblings claim NOT to do.
+
+**Existing confusable clusters (study these before adding to them):**
+
+- `icu_get_activity_*` family (details = SUMMARY / intervals = per-LAP / streams = RAW per-second)
+- `icu_search_activities` (LIGHT) vs `icu_search_activities_full` (FULL — heavy)
+- `icu_create_event` (ONE new) / `icu_bulk_create_events` (MANY new) / `icu_duplicate_events` (COPY existing forward)
+- `icu_get_wellness_data` (RANGE of days) vs `icu_get_wellness_for_date` (ONE specific date)
+- `icu_get_*_curves` (best-effort across durations) vs `icu_get_*_histogram` (time-in-zone distribution per activity)
+- `icu_*_message` (singular = write) vs `icu_*_messages` (plural = read)
 
 If adding to one of these clusters, study how the existing siblings differentiate and follow that pattern.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Two new MCP Resources: `intervals-icu://event-categories` (calendar event category enum + use-case mapping + training_availability values) and `intervals-icu://custom-item-schemas` (per-item_type `content` schema for `create_custom_item` / `update_custom_item` with INPUT_FIELD/ACTIVITY_FIELD/INTERVAL_FIELD constraints and worked examples). The tool descriptions now point at these instead of inlining the same prose every session.
+- Tool-selection accuracy: rewrote disambiguating first-sentences across 9 confusable tools — `icu_get_activity_details` / `icu_get_activity_intervals` / `icu_get_activity_streams`, `icu_search_activities` / `icu_search_activities_full`, `icu_get_wellness_data` / `icu_get_wellness_for_date`, and `icu_create_event` / `icu_bulk_create_events` / `icu_duplicate_events`. Each first sentence now leads with the distinguishing access pattern (SUMMARY / per-LAP / RAW; LIGHT / FULL; RANGE / ONE; ONE new / MANY new / COPY existing) so the LLM picks the right tool first instead of a wrong-tool round-trip.
 
 ### Changed
 - **Breaking — response shape:** Histogram tools now return `buckets` (was `bins`), each shaped `{<metric>_range: {min_*, max_*}, time_seconds}` where boundaries come straight from the API's `min`/`max` fields. The previous `count` field is dropped (the API doesn't return raw sample counts — `secs` is time-in-bucket).

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -103,16 +103,11 @@ async def get_activity_details(
     activity_id: Annotated[str, "Activity ID to fetch"],
     ctx: Context | None = None,
 ) -> str:
-    """Get detailed information for a specific activity.
+    """Fetch the headline SUMMARY of one activity — name, sport, date, distance, duration, training load, weather, plus all top-level metrics in a single JSON blob.
 
-    Returns comprehensive activity details including all metrics, weather,
-    and performance data.
-
-    Args:
-        activity_id: The unique ID of the activity
-
-    Returns:
-        JSON string with detailed activity information
+    Use for "how was my ride?", "tell me about activity X". For lap-by-lap or
+    per-interval breakdown use get_activity_intervals; for second-by-second
+    time-series use get_activity_streams.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -244,17 +239,11 @@ async def search_activities(
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Search for activities by name or tag.
+    """Search activities by name or tag, returning a LIGHT result list — id, name, type, date, distance, time only.
 
-    Searches the athlete's activity history for matching activities based on
-    name or tags. Useful for finding specific workouts or activity types.
-
-    Args:
-        query: Search term (e.g., "threshold", "long run", "race")
-        limit: Maximum number of results (default 30)
-
-    Returns:
-        JSON string with matching activities
+    Use this first for "find my X" queries. Only escalate to
+    search_activities_full when you specifically need power, HR, training
+    load, or intensity-factor data on the matches (heavier payload).
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -611,18 +600,10 @@ async def search_activities_full(
     limit: Annotated[int, "Maximum number of results to return"] = 30,
     ctx: Context | None = None,
 ) -> str:
-    """Search for activities by name or tag, returning complete activity details.
+    """Search activities by name or tag, returning FULL Activity objects with power, HR, training load, intensity factor, normalized power, weather — every metric per result.
 
-    Unlike the basic search, this returns full Activity objects with all metrics,
-    power data, heart rate, training load, and more. Use this when you need
-    detailed information about matching activities.
-
-    Args:
-        query: Search term (e.g., "threshold", "long run", "race", "#interval")
-        limit: Maximum number of results (default 30)
-
-    Returns:
-        JSON string with complete activity details for matches
+    Heavy payload. Use only when the lighter search_activities won't tell
+    you what you need (e.g. "find my threshold rides with NP above 250W").
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -18,31 +18,16 @@ async def get_activity_streams(
     ] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Get time-series data streams for an activity.
+    """Fetch RAW per-sample time-series of one activity — second-by-second arrays for power, HR, cadence, speed, altitude, GPS, temperature, grade, etc.
 
-    Returns second-by-second data for various metrics like power, heart rate,
-    cadence, speed, altitude, etc. This data is essential for detailed workout
-    analysis and visualization.
+    Heavy payload. Use only when you need the underlying signal for
+    visualization or custom analysis. Most "how was my ride?" questions
+    are better answered by get_activity_details (summary metrics) or
+    get_activity_intervals (per-lap breakdown).
 
-    Available stream types:
-    - watts: Power data
-    - heartrate: Heart rate data
-    - cadence: Cadence (rpm or spm)
-    - velocity_smooth: Smoothed speed
-    - altitude: Elevation
-    - distance: Cumulative distance
-    - time: Time stamps
-    - latlng: GPS coordinates
-    - temp: Temperature
-    - moving: Moving status
-    - grade_smooth: Gradient
-
-    Args:
-        activity_id: The unique ID of the activity
-        streams: Optional list of specific stream types to fetch
-
-    Returns:
-        JSON string with time-series data streams
+    Stream-type filter accepts any of: watts, heartrate, cadence,
+    velocity_smooth, altitude, distance, time, latlng, temp, moving,
+    grade_smooth.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -100,17 +85,12 @@ async def get_activity_intervals(
     activity_id: Annotated[str, "Activity ID to fetch intervals for"],
     ctx: Context | None = None,
 ) -> str:
-    """Get structured interval data for an activity.
+    """Fetch the per-LAP / per-interval breakdown of one activity — each segment with its target, actual power/HR/pace, and type (warm-up / work / rest / cool-down).
 
-    Returns the intervals/segments of a workout, including targets, actual performance,
-    and interval types (warm-up, work, rest, cool-down). Essential for analyzing
-    structured workouts and training compliance.
-
-    Args:
-        activity_id: The unique ID of the activity
-
-    Returns:
-        JSON string with interval data
+    Use for workout-compliance analysis, lap-by-lap review,
+    "did I hit my intervals?". For headline summary metrics use
+    get_activity_details; for raw second-by-second data use
+    get_activity_streams.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -196,7 +196,12 @@ async def create_event(
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create a calendar event.
+    """Create ONE new calendar event from scratch.
+
+    For two or more events in a single call, prefer bulk_create_events
+    over a loop. For copying existing events forward in time (repeating
+    a workout for N weeks), use duplicate_events — that tool reuses an
+    existing event's payload instead of taking new fields.
 
     For category guidance and the training_availability enum, read the
     intervals-icu://event-categories resource. For structured WORKOUT events,
@@ -475,11 +480,13 @@ async def bulk_create_events(
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create multiple calendar events in a single operation.
+    """Create MANY new calendar events in a single batch call (more efficient than looping create_event).
 
-    More efficient than calling create_event in a loop. Each event object accepts
-    the same fields as create_event. See intervals-icu://event-categories and
-    intervals-icu://workout-syntax for the referenced enums and DSL.
+    Accepts a JSON array of event objects, each shaped like a create_event
+    payload. For copying existing events forward use duplicate_events
+    instead — that reuses payloads rather than taking new fields. See
+    intervals-icu://event-categories and intervals-icu://workout-syntax
+    for the referenced enums and DSL.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -687,18 +694,12 @@ async def duplicate_events(
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Duplicate one or more calendar events.
+    """COPY existing events forward in time by N weeks.
 
-    Creates copies of the specified events, placed at weekly intervals from
-    the original dates. Useful for repeating workouts across multiple weeks.
-
-    Args:
-        event_ids: JSON array of event IDs to duplicate
-        num_copies: Number of copies to create (default 1)
-        weeks_between: Weeks between each copy (default 1)
-
-    Returns:
-        JSON string with the duplicated events
+    Use when the user says "repeat this workout for the next 4 weeks",
+    "duplicate Monday's run on the next 3 Mondays". Reuses the existing
+    events' payloads — different from create_event / bulk_create_events,
+    which both build NEW events from scratch.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -189,16 +189,11 @@ async def get_wellness_data(
     days_back: Annotated[int, "Number of days to look back"] = 7,
     ctx: Context | None = None,
 ) -> str:
-    """Get wellness data for recent days.
+    """Fetch wellness records over a RANGE of recent days (default last 7).
 
-    Returns wellness metrics including HRV, sleep, resting heart rate,
-    mood, fatigue, soreness, and other health markers.
-
-    Args:
-        days_back: Number of days to retrieve (default 7)
-
-    Returns:
-        JSON string with wellness data
+    Use for trends, weekly summaries, "how has my sleep been this week?",
+    recovery curves. For a single specific date use get_wellness_for_date
+    instead — this tool always returns a multi-day list.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -292,16 +287,11 @@ async def get_wellness_for_date(
     date: Annotated[str, "Date in YYYY-MM-DD format"],
     ctx: Context | None = None,
 ) -> str:
-    """Get wellness data for a specific date.
+    """Fetch the wellness record for ONE specific date.
 
-    Returns all wellness metrics for the specified date including sleep,
-    HRV, heart rate, mood, fatigue, and other health markers.
-
-    Args:
-        date: Date in ISO-8601 format (YYYY-MM-DD)
-
-    Returns:
-        JSON string with wellness data for the date
+    Use when the user names a date — "show my HRV for Monday",
+    "wellness on 2026-03-15", "how did I sleep last Thursday?". For
+    ranges, weeks, or trends use get_wellness_data.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")


### PR DESCRIPTION
## Summary

Rewrites the opening sentence of 9 tools whose names share prefixes/suffixes/nouns, so the LLM has a clearer routing signal between siblings. Pure documentation change — no behavior, no signatures, no response shapes touched.

Codifies the disambiguation technique in \`.claude/skills/add-tool/SKILL.md\` so future tools follow the same discipline.

Closes #30.

## Confusable clusters rewritten

| Cluster | Distinguisher | Tools |
|---|---|---|
| Activity detail | what's returned | \`get_activity_details\` (**SUMMARY** — top-level metrics blob) / \`get_activity_intervals\` (**per-LAP** breakdown) / \`get_activity_streams\` (**RAW** per-sample time-series) |
| Activity search | payload weight | \`search_activities\` (**LIGHT** — id/name/date) / \`search_activities_full\` (**FULL** — every metric) |
| Wellness query | scope | \`get_wellness_data\` (**RANGE** of days) / \`get_wellness_for_date\` (**ONE** specific date) |
| Event create | semantic | \`create_event\` (**ONE** new) / \`bulk_create_events\` (**MANY** new) / \`duplicate_events\` (**COPY** existing forward) |

## Technique

1. Lead the first sentence with the **distinguishing access pattern**, not the shared concept.
2. **One ALL-CAPS word per first sentence** on the disambiguator (SUMMARY / RAW / LIGHT / ONE / COPY, etc.). Anchors LLM attention to the choice axis without becoming noise.
3. **Cross-reference siblings explicitly** in the body — name them and say when to pick each.

## Smoke eval (Haiku 4.5, prompts 4 / 6 / 10, main vs branch)

| Prompt | Main | Branch | Verdict |
|---|---|---|---|
| 4: \"breakdown of yesterday's workout\" | Both \`details\` + \`intervals\` (details first) | Both \`details\` + \`intervals\` (intervals first) | Tie on call count; call *order* shifted per the per-LAP rewrite |
| 6: \"threshold rides with NP > 250W\" | \`search_activities_full\` ✓ | \`search_activities_full\` ✓ | Tie — both correct |
| 10: \"add an easy run for tomorrow, Wednesday, and Friday\" | \`bulk_create_events\` ✓ | \`bulk_create_events\` ✓ | Tie — both correct |

**Honest read:** on Haiku 4.5, the original descriptions already disambiguated these clusters well enough that the rewrites didn't reduce wrong-tool round-trips. Smaller / cheaper models (Haiku 3.5, GPT-4o-mini, local OSS) may show larger gains — we haven't tested those.

## Why merge anyway

The rewrites earn their keep on independent grounds:

- **Tighter prose** — ~150 tokens lighter across the 9 tools (small, on top of #47's ~1,200).
- **Codified discipline** — \`.claude/skills/add-tool/SKILL.md\` now documents the disambiguator-caps technique so new additions to confusable clusters follow it without rediscovery.
- **No regressions** observed; routing remains correct where it was correct.
- **Visible code-quality improvement** — clusters are now obviously distinguishable to a reviewer.

This isn't \"big accuracy win\" — it's \"good hygiene that pays off whenever a smaller / cheaper model is involved.\"

## Net change

| File | Δ lines |
|---|---:|
| \`activities.py\` | -29 |
| \`activity_analysis.py\` | -30 |
| \`event_management.py\` | -3 |
| \`wellness.py\` | -14 |
| \`.claude/skills/add-tool/SKILL.md\` | +12 |
| \`CHANGELOG.md\` | +1 |
| **Total** | **-63 net** |

## SemVer

Pure description change. No bump triggered by this PR.

## Cache invalidation

One-time cache bust on rollout. Steady-state neutral.

## Checklist

- [x] \`make can-release\` passes locally (tests, ruff, pyright, build, twine, pyroma). 139/139 tests pass.
- [x] New tools have a corresponding respx-mocked test file — N/A, no new tools.
- [x] Public-facing behavior changes are reflected in the README or \`docs/\` — N/A, no behavior change. CHANGELOG entry added.
- [x] New MCP tools follow the \`icu_\` prefix convention — N/A, no new tools.
- [x] No API keys, athlete IDs, or other credentials are committed.

## Test plan

- [x] \`make can-release\` green.
- [x] All cluster tests pass (\`test_activity_tools\`, \`test_event_tools\`, \`test_wellness_tools\`, \`test_transport_integration\`).
- [x] Haiku 4.5 smoke on prompts 4/6/10 against both branches — no regressions; rewrites at-best a tie on routing accuracy for this model class.

## Follow-up

Next in the v3.0.0 sequence: #46 (long-tail trim), then cut the release.