### PR TITLE
feat(eval): smoke-eval harness for first-tool-call routing accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ exports/
 
 # MCP local config
 .mcp.json
+
+# Smoke eval results
+.smoke-eval/

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,19 @@ run: ## Run the MCP server locally
 shell: ## Open a Python shell with the project context
 	uv run python
 
+##@ LLM smoke eval (costs API money; NOT part of `make test`)
+
+smoke-eval: ## Run smoke eval against current branch (requires ANTHROPIC_API_KEY; costs ~$0.07/run)
+	uv run python scripts/smoke_eval.py
+
+smoke-eval/save: ## Run smoke eval and save results to .smoke-eval/<branch>.json
+	@mkdir -p .smoke-eval
+	@branch=$$(git rev-parse --abbrev-ref HEAD | tr / -); \
+		uv run python scripts/smoke_eval.py --output .smoke-eval/$$branch.json
+
+smoke-eval/diff: ## Diff two smoke-eval result files (usage: make smoke-eval/diff BASE=a.json BRANCH=b.json)
+	uv run python scripts/smoke_eval_diff.py $(BASE) $(BRANCH)
+
 ##@ Docker
 
 docker/build: ## Build Docker image locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "pyright>=1.1.408",
     "pytest-cov>=7.1.0",
     "asgi-lifespan>=2.1.0",
+    "anthropic>=0.40.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/smoke_eval.py
+++ b/scripts/smoke_eval.py
@@ -1,0 +1,194 @@
+"""Smoke eval for first-tool-call routing accuracy.
+
+Hits the Anthropic API with the MCP server's tool definitions and a set of
+prompts, then records which tool the model picked first. Pure routing test —
+never sends a tool_result back, so no MCP tool is ever executed. The
+intervals.icu API is never touched.
+
+Usage:
+    ANTHROPIC_API_KEY=... uv run python scripts/smoke_eval.py
+    ANTHROPIC_API_KEY=... uv run python scripts/smoke_eval.py --output results.json
+    uv run python scripts/smoke_eval.py --cases tests/smoke_eval.json --model claude-haiku-4-5-20251001
+
+Costs ~$0.07 per full run on Haiku 4.5. NOT part of `make test`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import anthropic
+from fastmcp import Client
+
+from intervals_icu_mcp.server import mcp
+
+# Hard guard: this harness must never execute any tool. We accept tool_use blocks
+# from the model and inspect them, but we never construct or send a tool_result.
+# Changing this constant requires a deliberate code change, not a flag.
+DRY_RUN = True
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_CASES_PATH = Path(__file__).parent.parent / "tests" / "smoke_eval.json"
+
+
+@dataclass
+class CaseResult:
+    id: str
+    prompt: str
+    expected: str
+    got: str | None
+    passed: bool
+    bucket: str
+    notes: str
+
+
+async def get_anthropic_tool_defs() -> list[dict[str, Any]]:
+    """Return MCP tool defs converted to Anthropic API tool-use format.
+
+    Differences from the MCP protocol's Tool type:
+    - Field rename: `inputSchema` -> `input_schema`.
+    - Drop fields Anthropic doesn't consume: annotations, meta, icons, etc.
+    """
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+    return [
+        {
+            "name": t.name,
+            "description": t.description or "",
+            "input_schema": t.inputSchema,
+        }
+        for t in tools
+    ]
+
+
+def extract_first_tool_use(response: anthropic.types.Message) -> str | None:
+    """Return the name of the first tool_use block, or None if model didn't pick one."""
+    for block in response.content:
+        if block.type == "tool_use":
+            return block.name
+    return None
+
+
+def run_case(
+    client: anthropic.Anthropic,
+    case: dict[str, Any],
+    tools: list[dict[str, Any]],
+    model: str,
+) -> CaseResult:
+    response = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        tools=tools,  # type: ignore[arg-type]
+        messages=[{"role": "user", "content": case["prompt"]}],
+    )
+    got = extract_first_tool_use(response)
+    expected = case["expected_tool"]
+    return CaseResult(
+        id=case["id"],
+        prompt=case["prompt"],
+        expected=expected,
+        got=got,
+        passed=(got == expected),
+        bucket=case.get("bucket", ""),
+        notes=case.get("notes", ""),
+    )
+
+
+def print_summary(results: list[CaseResult]) -> None:
+    width_id = max(len(r.id) for r in results) + 2
+    width_exp = max(len(r.expected) for r in results) + 2
+    print(f"{'STATUS':<6} {'CASE':<{width_id}} {'EXPECTED':<{width_exp}} GOT")
+    print("-" * (10 + width_id + width_exp + 35))
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        got = r.got or "(none)"
+        print(f"{status:<6} {r.id:<{width_id}} {r.expected:<{width_exp}} {got}")
+    print()
+    passed = sum(1 for r in results if r.passed)
+    print(f"{passed}/{len(results)} passed")
+    failed_ids = [r.id for r in results if not r.passed]
+    if failed_ids:
+        print(f"Failed cases: {', '.join(failed_ids)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        default=DEFAULT_CASES_PATH,
+        help=f"Path to eval cases JSON (default: {DEFAULT_CASES_PATH.relative_to(Path.cwd()) if DEFAULT_CASES_PATH.is_relative_to(Path.cwd()) else DEFAULT_CASES_PATH})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to save results JSON (for `smoke_eval_diff.py`)",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Anthropic model ID (default: {DEFAULT_MODEL})",
+    )
+    args = parser.parse_args()
+
+    assert DRY_RUN, "DRY_RUN must remain True; this harness never executes tools"
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            "Error: ANTHROPIC_API_KEY is required. Get one at https://console.anthropic.com.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.cases.exists():
+        print(f"Error: cases file not found: {args.cases}", file=sys.stderr)
+        return 2
+
+    cases = json.loads(args.cases.read_text())
+    print("Loading MCP tool defs (in-process)...")
+    tools = asyncio.run(get_anthropic_tool_defs())
+    print(f"Loaded {len(tools)} tools. Running {len(cases)} cases against {args.model}.")
+    print()
+
+    client = anthropic.Anthropic()
+    results: list[CaseResult] = []
+    for i, case in enumerate(cases, 1):
+        print(f"[{i}/{len(cases)}] {case['id']}...", end="", flush=True)
+        try:
+            result = run_case(client, case, tools, args.model)
+        except anthropic.APIError as e:
+            print(f" ERROR: {e}")
+            result = CaseResult(
+                id=case["id"],
+                prompt=case["prompt"],
+                expected=case["expected_tool"],
+                got=None,
+                passed=False,
+                bucket=case.get("bucket", ""),
+                notes=f"API error: {e}",
+            )
+        else:
+            print(" PASS" if result.passed else f" FAIL (got {result.got})")
+        results.append(result)
+
+    print()
+    print_summary(results)
+
+    if args.output:
+        args.output.write_text(json.dumps([asdict(r) for r in results], indent=2))
+        print(f"\nResults saved to {args.output}")
+
+    failed = sum(1 for r in results if not r.passed)
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_eval_diff.py
+++ b/scripts/smoke_eval_diff.py
@@ -1,0 +1,95 @@
+"""Diff two smoke-eval result files.
+
+Highlights cases where one run passed and the other failed, surfacing
+regressions and wins.
+
+Usage:
+    uv run python scripts/smoke_eval_diff.py baseline.json branch.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load(path: Path) -> dict[str, dict[str, Any]]:
+    return {r["id"]: r for r in json.loads(path.read_text())}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline", type=Path, help="Baseline results JSON (e.g. main)")
+    parser.add_argument("branch", type=Path, help="Branch results JSON")
+    args = parser.parse_args()
+
+    baseline = load(args.baseline)
+    branch = load(args.branch)
+
+    all_ids = sorted(set(baseline) | set(branch))
+
+    wins: list[tuple[str, str, str]] = []
+    regressions: list[tuple[str, str, str]] = []
+    same_pass: list[str] = []
+    same_fail: list[tuple[str, str, str, str]] = []
+    routing_changed: list[tuple[str, str, str]] = []
+
+    for case_id in all_ids:
+        b = baseline.get(case_id)
+        n = branch.get(case_id)
+        if b is None:
+            print(f"[NEW]  {case_id} only in branch")
+            continue
+        if n is None:
+            print(f"[GONE] {case_id} only in baseline")
+            continue
+        b_got = b.get("got") or "(none)"
+        n_got = n.get("got") or "(none)"
+        b_pass = b["passed"]
+        n_pass = n["passed"]
+        if b_pass and n_pass:
+            same_pass.append(case_id)
+        elif not b_pass and not n_pass:
+            same_fail.append((case_id, b["expected"], b_got, n_got))
+        elif n_pass and not b_pass:
+            wins.append((case_id, b_got, n_got))
+        elif b_pass and not n_pass:
+            regressions.append((case_id, b_got, n_got))
+        elif b_got != n_got:
+            routing_changed.append((case_id, b_got, n_got))
+
+    def hdr(label: str) -> None:
+        print(f"\n=== {label} ===")
+
+    if wins:
+        hdr(f"WINS ({len(wins)}) — branch passes, baseline failed")
+        for case_id, b_got, n_got in wins:
+            print(f"  {case_id}: {b_got!r} -> {n_got!r}")
+
+    if regressions:
+        hdr(f"REGRESSIONS ({len(regressions)}) — baseline passed, branch fails")
+        for case_id, b_got, n_got in regressions:
+            print(f"  {case_id}: {b_got!r} -> {n_got!r}")
+
+    if routing_changed:
+        hdr(f"ROUTING CHANGED, BOTH STILL PASS ({len(routing_changed)})")
+        for case_id, b_got, n_got in routing_changed:
+            print(f"  {case_id}: {b_got!r} -> {n_got!r}")
+
+    if same_fail:
+        hdr(f"STILL FAILING ({len(same_fail)}) — broken on both")
+        for case_id, expected, b_got, n_got in same_fail:
+            print(f"  {case_id}: expected {expected!r}; baseline={b_got!r}, branch={n_got!r}")
+
+    print()
+    print(f"Summary: {len(wins)} wins, {len(regressions)} regressions, "
+          f"{len(same_pass)} unchanged passes, {len(same_fail)} unchanged fails.")
+
+    return 1 if regressions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/intervals_icu_mcp/auth.py
+++ b/src/intervals_icu_mcp/auth.py
@@ -19,6 +19,7 @@ class ICUConfig(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        extra="ignore",
     )
 
     intervals_icu_api_key: str = ""

--- a/tests/smoke_eval.json
+++ b/tests/smoke_eval.json
@@ -1,0 +1,247 @@
+[
+  {
+    "id": "wellness_log_rpe",
+    "prompt": "Log RPE 7 for today",
+    "expected_tool": "icu_update_wellness",
+    "bucket": "a",
+    "notes": "Pure schema; no state needed"
+  },
+  {
+    "id": "wellness_range_week",
+    "prompt": "How has my sleep been this week?",
+    "expected_tool": "icu_get_wellness_data",
+    "bucket": "a",
+    "notes": "Wellness range vs single-date disambiguation"
+  },
+  {
+    "id": "wellness_specific_date",
+    "prompt": "What was my HRV on Monday?",
+    "expected_tool": "icu_get_wellness_for_date",
+    "bucket": "a",
+    "notes": "Single named date routes to for_date, not range"
+  },
+  {
+    "id": "athlete_profile",
+    "prompt": "Show my athlete profile",
+    "expected_tool": "icu_get_athlete_profile",
+    "bucket": "a",
+    "notes": "Basic routing"
+  },
+  {
+    "id": "fitness_summary",
+    "prompt": "What's my current CTL and TSB?",
+    "expected_tool": "icu_get_fitness_summary",
+    "bucket": "a",
+    "notes": "Fitness terminology should anchor"
+  },
+  {
+    "id": "recent_activities",
+    "prompt": "Show my last 5 rides",
+    "expected_tool": "icu_get_recent_activities",
+    "bucket": "a",
+    "notes": "Default activity-list query"
+  },
+  {
+    "id": "search_light",
+    "prompt": "Find my threshold rides from last month",
+    "expected_tool": "icu_search_activities",
+    "bucket": "a",
+    "notes": "No specific metric named → LIGHT search"
+  },
+  {
+    "id": "search_full_with_metric",
+    "prompt": "Find my threshold rides where normalized power was above 250W",
+    "expected_tool": "icu_search_activities_full",
+    "bucket": "a",
+    "notes": "NP metric only in FULL payload"
+  },
+  {
+    "id": "calendar_week",
+    "prompt": "What's on my calendar this week?",
+    "expected_tool": "icu_get_calendar_events",
+    "bucket": "a",
+    "notes": "Broad calendar query"
+  },
+  {
+    "id": "upcoming_workouts",
+    "prompt": "What's my next workout?",
+    "expected_tool": "icu_get_upcoming_workouts",
+    "bucket": "a",
+    "notes": "Filtered to workouts only"
+  },
+  {
+    "id": "power_curves",
+    "prompt": "Show my power curve for this season",
+    "expected_tool": "icu_get_power_curves",
+    "bucket": "a",
+    "notes": "Cross-activity curve, not single-activity histogram"
+  },
+  {
+    "id": "hr_curves",
+    "prompt": "Show my best 5-minute heart rate over the last year",
+    "expected_tool": "icu_get_hr_curves",
+    "bucket": "a",
+    "notes": "Best-effort across activities = curve"
+  },
+  {
+    "id": "pace_curves",
+    "prompt": "Show my pace curve for the last 3 months",
+    "expected_tool": "icu_get_pace_curves",
+    "bucket": "a",
+    "notes": "Run/swim curve"
+  },
+  {
+    "id": "workout_library",
+    "prompt": "Show my workout library",
+    "expected_tool": "icu_get_workout_library",
+    "bucket": "a",
+    "notes": "Library entry point"
+  },
+  {
+    "id": "custom_items_list",
+    "prompt": "List my custom charts",
+    "expected_tool": "icu_get_custom_items",
+    "bucket": "a",
+    "notes": "Custom items list"
+  },
+  {
+    "id": "sport_settings_list",
+    "prompt": "What are my sport settings?",
+    "expected_tool": "icu_get_sport_settings",
+    "bucket": "a",
+    "notes": "Settings read"
+  },
+  {
+    "id": "update_ftp",
+    "prompt": "Update my FTP to 280 watts for sport setting 1",
+    "expected_tool": "icu_update_sport_settings",
+    "bucket": "a",
+    "notes": "FTP update routes to update, not apply or create"
+  },
+  {
+    "id": "create_event_one",
+    "prompt": "Add a recovery ride for tomorrow",
+    "expected_tool": "icu_create_event",
+    "bucket": "a",
+    "notes": "Single event creation"
+  },
+  {
+    "id": "create_event_many",
+    "prompt": "Add an easy run for tomorrow, Wednesday, and Friday",
+    "expected_tool": "icu_bulk_create_events",
+    "bucket": "a",
+    "notes": "Multi-day → bulk variant"
+  },
+  {
+    "id": "gear_list",
+    "prompt": "Show me my gear",
+    "expected_tool": "icu_get_gear_list",
+    "bucket": "a",
+    "notes": "Gear inventory"
+  },
+  {
+    "id": "create_gear",
+    "prompt": "Add my new road bike as gear",
+    "expected_tool": "icu_create_gear",
+    "bucket": "a",
+    "notes": "Gear creation"
+  },
+  {
+    "id": "create_custom_item_field",
+    "prompt": "Add a custom RPE input field on my wellness page",
+    "expected_tool": "icu_create_custom_item",
+    "bucket": "a",
+    "notes": "Custom item creation"
+  },
+  {
+    "id": "search_intervals_cross",
+    "prompt": "Find all my threshold intervals from this year",
+    "expected_tool": "icu_search_intervals",
+    "bucket": "a",
+    "notes": "Cross-activity interval search (different from get_activity_intervals)"
+  },
+  {
+    "id": "activity_details_id",
+    "prompt": "Tell me about activity i99999999",
+    "expected_tool": "icu_get_activity_details",
+    "bucket": "b",
+    "notes": "Fake ID; routes to details for summary-style request"
+  },
+  {
+    "id": "activity_intervals_id",
+    "prompt": "Show the per-lap breakdown of activity i99999999",
+    "expected_tool": "icu_get_activity_intervals",
+    "bucket": "b",
+    "notes": "Per-lap signal routes to intervals"
+  },
+  {
+    "id": "activity_streams_id",
+    "prompt": "Get the second-by-second power data for activity i99999999",
+    "expected_tool": "icu_get_activity_streams",
+    "bucket": "b",
+    "notes": "Raw time-series request routes to streams"
+  },
+  {
+    "id": "activity_breakdown_ambiguous",
+    "prompt": "Give me the breakdown of activity i99999999",
+    "expected_tool": "icu_get_activity_intervals",
+    "bucket": "b",
+    "notes": "Disambiguator test: 'breakdown' should route to per-LAP intervals not summary details"
+  },
+  {
+    "id": "power_histogram_id",
+    "prompt": "Show power distribution for activity i99999999",
+    "expected_tool": "icu_get_power_histogram",
+    "bucket": "b",
+    "notes": "Distribution within one activity = histogram, not curve"
+  },
+  {
+    "id": "duplicate_events_id",
+    "prompt": "Duplicate event 99999999 onto the next 4 Mondays",
+    "expected_tool": "icu_duplicate_events",
+    "bucket": "b",
+    "notes": "Copy existing, not create new"
+  },
+  {
+    "id": "get_event_id",
+    "prompt": "Get details for calendar event 99999999",
+    "expected_tool": "icu_get_event",
+    "bucket": "b",
+    "notes": "Single event by ID"
+  },
+  {
+    "id": "activity_messages_read",
+    "prompt": "Show comments on activity i99999999",
+    "expected_tool": "icu_get_activity_messages",
+    "bucket": "b",
+    "notes": "Plural = READ"
+  },
+  {
+    "id": "activity_messages_write",
+    "prompt": "Add a note 'felt strong today' to activity i99999999",
+    "expected_tool": "icu_add_activity_message",
+    "bucket": "b",
+    "notes": "Singular = WRITE"
+  },
+  {
+    "id": "download_original",
+    "prompt": "Download the original file for activity i99999999",
+    "expected_tool": "icu_download_activity_file",
+    "bucket": "b",
+    "notes": "Original format vs FIT/GPX conversion"
+  },
+  {
+    "id": "best_efforts_id",
+    "prompt": "What are my best 5-minute power efforts in activity i99999999?",
+    "expected_tool": "icu_get_best_efforts",
+    "bucket": "b",
+    "notes": "Within-activity best efforts (not cross-activity curves)"
+  },
+  {
+    "id": "apply_training_plan_id",
+    "prompt": "Apply training plan folder 12345 starting next Monday",
+    "expected_tool": "icu_apply_training_plan",
+    "bucket": "b",
+    "notes": "Schedule a plan onto the calendar"
+  }
+]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.103.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/57/0b758b08cf4606c94d63a997d67a0063f7438efbaf81cfedd0d7c0c69d67/anthropic-0.103.1.tar.gz", hash = "sha256:21c12f4fc0fdd87a2e80d58479cd0af640062b3cfb82bbfa01c7977acd4defeb", size = 848877, upload-time = "2026-05-19T15:43:27.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/ec/cf357cf571377a39552c1530390a9b79bbdb6ea463f48fbe4e3624141e3b/anthropic-0.103.1-py3-none-any.whl", hash = "sha256:b9a523fac34e64caf6ee55fdbda213950e6a744b906fce100d34909aad2cd8f4", size = 832551, upload-time = "2026-05-19T15:43:29.663Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -400,6 +419,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -582,6 +610,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anthropic" },
     { name = "asgi-lifespan" },
     { name = "pyright" },
     { name = "pytest" },
@@ -602,6 +631,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anthropic", specifier = ">=0.40.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.4.2" },
@@ -654,6 +684,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a small Python harness that drives the Anthropic API with the MCP server's tool definitions and a fixed set of routing-test prompts, recording which tool the model picks first for each. Pure routing test — never sends a `tool_result` back, so no MCP tool is ever executed and the intervals.icu API is never touched.

Used in PR #54 to measure that #53 + #46 caused **0 routing regressions** and **+2 routing wins** vs main (28/35 → 30/35 on Haiku 4.5).

## Why this matters

PR #47 and PR #53 both shipped with manual smoke tests — slow (~30 min for full sweep), unreliable (model behavior is non-deterministic on single runs), and not bisectable. After two PRs of this pattern, we hit "manual smoke is unsustainable." This PR is the durable answer.

Every future PR that touches tool descriptions (#46 today, #29 if we pursue input_examples, anything new added per the add-tool skill) can now run `make smoke-eval/save` on its branch and `make smoke-eval/diff` against a saved baseline to measure routing impact directly.

## How it works

| File | Purpose |
|---|---|
| `scripts/smoke_eval.py` | Loads MCP tool defs in-process, converts to Anthropic tool-use schema (`inputSchema` → `input_schema`), runs each prompt, extracts first `tool_use` block from the response |
| `scripts/smoke_eval_diff.py` | Diffs two result files; surfaces wins / regressions / changed-but-still-passing / still-failing |
| `tests/smoke_eval.json` | 35 cases bucketed by (a) pure schema (no state) and (b) fake-ID (no real account data); zero account-data dependencies |
| `Makefile` | `smoke-eval`, `smoke-eval/save`, `smoke-eval/diff` targets |

## Hard guarantees

1. **`DRY_RUN = True` constant**, asserted at runtime. Changing it requires a code change, not a flag.
2. **No `tool_result` is ever constructed or sent back** — only the first `tool_use` is inspected. Tools cannot execute.
3. **No `ICUClient` import, no `ICU_API_KEY` read** — the harness has no path to the intervals.icu API.
4. **Eval cases are designed to be account-state-independent** — bucket (a) prompts route from tool schema alone; bucket (b) prompts use clearly-fake IDs (`i99999999`).

## Auth fix included

`src/intervals_icu_mcp/auth.py`: added `extra="ignore"` to `ICUConfig.model_config` so `.env` can host secrets for other tools (like `ANTHROPIC_API_KEY`) without breaking Pydantic validation of the intervals-icu config. One-line change.

## Cost

~$0.07 per full eval run on Haiku 4.5 (~70k input tokens × $1/M). NOT part of `make test` — separate target to avoid surprising users with API costs on routine test runs.

## Empirical result on PR #54

Used to validate PR #54 (long-tail trim). Diff output:

```
=== WINS (2) — branch passes, baseline failed ===
  activity_intervals_id: 'icu_get_activity_details' -> 'icu_get_activity_intervals'
  search_light: 'icu_search_activities_full' -> 'icu_search_activities'

=== STILL FAILING (5) — broken on both ===
  activity_breakdown_ambiguous, apply_training_plan_id, create_event_many,
  create_event_one, wellness_specific_date
  (prompt-design issues; same on both branches; not caused by trims)

Summary: 2 wins, 0 regressions, 28 unchanged passes, 5 unchanged fails.
```

## Checklist

- [x] `make can-release` passes locally (lint + type-check applies to scripts/ too)
- [x] No credentials committed (eval cases use only fake IDs; ANTHROPIC_API_KEY comes from env)
- [x] `.smoke-eval/` added to `.gitignore` (local result files stay out of git)
- [x] `make smoke-eval` is NOT part of `make test`; opt-in, costs API money

## Follow-up

The 5 unchanged-failing cases in the current eval set are noisy prompts the model treats as conversational. Refining those prompts is fixture work, separate from any release. File as P3 follow-up if/when motivated.

Future eval cases that should be added as the project grows:
- Bucket (b) cases for any tool added in `tools/` modules
- Bucket (c) cases injecting fake context for chain-of-tools scenarios (low priority; current single-call coverage is enough)