### PR TITLE
feat(activity): nutrition section, calories rename, scale metadata (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `icu_get_activity_details` now surfaces a dedicated `nutrition` section grouping `calories_burned`, `carbs_ingested_g`, and `carbs_used_g`. `carbs_used` is a new field on the `Activity` model (was previously dropped on the floor). The `_g` suffix on carb fields signals grams (matching the wellness-side `carbohydrates_g` convention).
+- `icu_get_activity_details` now emits `metadata.subjective_scales` (`{"feel": "1-5", "rpe": "1-10"}`) whenever the corresponding values are present, so downstream LLMs stop interpreting raw ordinals on an assumed 0-10 scale.
+
+### Changed
+- **Breaking — response shape:** `icu_get_activity_details` renamed the `calories` output key to `calories_burned` and moved it out of the `other` section into the new `nutrition` section. The API field is energy expenditure; the prior label collided with the wellness-side `calories_consumed`/`kcalConsumed` (intake), confusing intake-vs-expenditure comparisons.
+
 ## [3.0.0] — 2026-05-20
 
 This release focuses on **token efficiency** and **tool-selection accuracy**. Combined effect: ~3,300-3,500 fewer tokens per default-mode session (~35% of the pre-release tool-description budget). First-tool-call routing accuracy on Haiku 4.5 improved from 28/35 (80%) on the pre-trim baseline to 30/35 (86%) on the merged set, measured by the new smoke-eval harness (0 regressions).

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.hhopke/intervals-icu-mcp",
-  "description": "MCP server for Intervals.icu — access training, wellness, and performance data from LLMs.",
+  "description": "Read/write Intervals.icu MCP server — 55+ tools across activities, streams, wellness, calendar, gear, and sport zones, plus structured workout generation for cycling, running, and swimming.",
   "repository": {
     "url": "https://github.com/hhopke/intervals-icu-mcp",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "intervals-icu-mcp",
-      "version": "1.1.1",
+      "version": "0.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -105,6 +105,7 @@ class Activity(ActivitySummary):
     description: str | None = None
     calories: int | None = None
     carbs_ingested: int | None = None
+    carbs_used: int | None = None
     device_name: str | None = None
     max_heartrate: int | None = None
     max_speed: float | None = None

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -186,6 +186,17 @@ async def get_activity_details(
             if training_metrics:
                 activity_data["training"] = training_metrics
 
+            # Nutrition (intake + expenditure)
+            nutrition: dict[str, Any] = {}
+            if activity.calories:
+                nutrition["calories_burned"] = activity.calories
+            if activity.carbs_ingested is not None:
+                nutrition["carbs_ingested_g"] = activity.carbs_ingested
+            if activity.carbs_used is not None:
+                nutrition["carbs_used_g"] = activity.carbs_used
+            if nutrition:
+                activity_data["nutrition"] = nutrition
+
             # Subjective metrics
             subjective: dict[str, Any] = {}
             if activity.feel:
@@ -197,8 +208,6 @@ async def get_activity_details(
 
             # Other info
             other_info: dict[str, Any] = {}
-            if activity.calories:
-                other_info["calories"] = activity.calories
             if activity.device_name:
                 other_info["device"] = activity.device_name
             if activity.trainer or activity.indoor:
@@ -213,9 +222,20 @@ async def get_activity_details(
             if strava_note:
                 analysis["data_availability"] = strava_note
 
+            metadata: dict[str, Any] = {}
+            if activity.feel is not None or activity.perceived_exertion is not None:
+                scales = {}
+                if activity.feel is not None:
+                    scales["feel"] = "1-5"
+                if activity.perceived_exertion is not None:
+                    scales["rpe"] = "1-10"
+                if scales:
+                    metadata["subjective_scales"] = scales
+
             return ResponseBuilder.build_response(
                 data=activity_data,
                 analysis=analysis if analysis else None,
+                metadata=metadata if metadata else None,
                 query_type="activity_details",
             )
 

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -3,7 +3,6 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from httpx import Response
 
 from intervals_icu_mcp.tools.activities import (
@@ -148,7 +147,6 @@ class TestActivityTools:
         assert response["data"]["count"] == 1
         assert response["data"]["activities"][0]["name"] == "Bulk Ride"
 
-    @pytest.mark.asyncio
     async def test_get_activity_details_nutrition_section(self, mock_config, respx_mock):
         """Nutrition fields are grouped, calories renamed to calories_burned."""
         mock_ctx = MagicMock()
@@ -180,7 +178,6 @@ class TestActivityTools:
         assert "calories" not in response["data"].get("other", {})
         assert "calories" not in nutrition
 
-    @pytest.mark.asyncio
     async def test_get_activity_details_subjective_scale_metadata(self, mock_config, respx_mock):
         """Scale metadata accompanies feel (1-5) and RPE (1-10)."""
         mock_ctx = MagicMock()
@@ -206,7 +203,6 @@ class TestActivityTools:
         assert response["data"]["subjective"] == {"feel": 4, "rpe": 7}
         assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
 
-    @pytest.mark.asyncio
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""
         mock_ctx = MagicMock()
@@ -235,7 +231,6 @@ class TestActivityTools:
         assert nutrition["carbs_ingested_g"] == 0  # zero is meaningful, must be preserved
         assert "carbs_used_g" not in nutrition
 
-    @pytest.mark.asyncio
     async def test_get_activity_details_no_subjective_no_scale_metadata(self, mock_config, respx_mock):
         """When feel/RPE are absent, subjective_scales metadata is also absent."""
         mock_ctx = MagicMock()

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -3,11 +3,13 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from httpx import Response
 
 from intervals_icu_mcp.tools.activities import (
     bulk_create_manual_activities,
     delete_activity,
+    get_activity_details,
     update_activity,
     update_activity_streams,
 )
@@ -145,3 +147,114 @@ class TestActivityTools:
         assert "data" in response
         assert response["data"]["count"] == 1
         assert response["data"]["activities"][0]["name"] == "Bulk Ride"
+
+    @pytest.mark.asyncio
+    async def test_get_activity_details_nutrition_section(self, mock_config, respx_mock):
+        """Nutrition fields are grouped, calories renamed to calories_burned."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "calories": 500,
+                    "carbs_ingested": 45,
+                    "carbs_used": 60,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        nutrition = response["data"]["nutrition"]
+        assert nutrition["calories_burned"] == 500
+        assert nutrition["carbs_ingested_g"] == 45
+        assert nutrition["carbs_used_g"] == 60
+        # Old key must be gone from output (breaking change documented in CHANGELOG)
+        assert "calories" not in response["data"].get("other", {})
+        assert "calories" not in nutrition
+
+    @pytest.mark.asyncio
+    async def test_get_activity_details_subjective_scale_metadata(self, mock_config, respx_mock):
+        """Scale metadata accompanies feel (1-5) and RPE (1-10)."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "feel": 4,
+                    "perceived_exertion": 7,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"feel": 4, "rpe": 7}
+        assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
+
+    @pytest.mark.asyncio
+    async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
+        """Nutrition section omits null fields; preserves zero values."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "calories": 400,
+                    "carbs_ingested": 0,
+                    # carbs_used omitted entirely
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        nutrition = response["data"]["nutrition"]
+        assert nutrition["calories_burned"] == 400
+        assert nutrition["carbs_ingested_g"] == 0  # zero is meaningful, must be preserved
+        assert "carbs_used_g" not in nutrition
+
+    @pytest.mark.asyncio
+    async def test_get_activity_details_no_subjective_no_scale_metadata(self, mock_config, respx_mock):
+        """When feel/RPE are absent, subjective_scales metadata is also absent."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert "subjective" not in response["data"]
+        assert "subjective_scales" not in response.get("metadata", {})


### PR DESCRIPTION
## Summary

- Adds a `nutrition` section to `icu_get_activity_details` output containing `calories_burned`, `carbs_ingested_g`, and `carbs_used_g`.
- Adds `carbs_used` to the `Activity` Pydantic model (was missing — API returns it but we dropped it).
- Renames output key `calories` → `calories_burned` (**breaking**, see Notes). Old location under `other` is removed.
- Adds `metadata.subjective_scales` (`{"feel": "1-5", "rpe": "1-10"}`) when those values are present, so LLMs stop interpreting the raw ordinals on an assumed 0-10 scale.

Closes #13.

## Notes / scope correction

The original issue asked for `carbohydrates`, `protein`, and `fat_total` to be added to the `Activity` model. **Verified against the live API and the OpenAPI spec: those fields do not exist on activity responses** — they are wellness-only and already correctly handled by `models.Wellness` / `tools/wellness.py` (`carbohydrates_g`, `protein_g`, `fat_total_g`). So the PR drops that part and instead surfaces `carbs_used`, which IS a real activity field and was previously being ignored.

The `calories_burned` rename and scale-metadata pieces from the issue stand and ship as-is.

## Test plan

- [x] `make test/activity` — 19 passed (4 new tests for nutrition section, partial nutrition, scale metadata, scale-metadata-absent edge case)
- [x] `make lint` — ruff + pyright clean
- [x] Manual: hit a real activity via the MCP tool and confirm the `nutrition` section appears and `calories` is gone from `other`