### PR TITLE
docs(readme): add Glama badge + Cursor install button in Quick Start, drop Python 3.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 > Originally based on [eddmann/intervals-icu-mcp](https://github.com/eddmann/intervals-icu-mcp) (MIT licensed). This project is an independent continuation with significant bug fixes and new features — see [CHANGELOG.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/CHANGELOG.md) for details.
 
 [![Tests](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/hhopke/intervals-icu-mcp/actions/workflows/test.yml)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![intervals-icu-mcp MCP server](https://glama.ai/mcp/servers/hhopke/intervals-icu-mcp/badges/score.svg)](https://glama.ai/mcp/servers/hhopke/intervals-icu-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/hhopke/intervals-icu-mcp/blob/main/LICENSE)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/hhopke/intervals-icu-mcp/pkgs/container/intervals-icu-mcp)
 
@@ -19,7 +19,9 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Quick Start
 
-Running with Claude Desktop, in 30 seconds:
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-light.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=intervals-icu&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJpbnRlcnZhbHMtaWN1LW1jcCJdLCJlbnYiOnsiSU5URVJWQUxTX0lDVV9BUElfS0VZIjoiIiwiSU5URVJWQUxTX0lDVV9BVEhMRVRFX0lEIjoiIn19)
+
+Or for Claude Desktop, in 30 seconds:
 
 1. Get your [API key and athlete ID](#intervalsicu-api-key-setup)
 2. Add this to your Claude Desktop config:


### PR DESCRIPTION
Three small README polish items.

## Top badge row

```
[Tests] [Glama MCP] [License: MIT] [Docker]
```

- **Add:** `Glama MCP server` score badge.
- **Drop:** `Python 3.11+` — purely static, duplicates info already in `pyproject.toml` and `server.json`. `uvx` installs surface version mismatches with a clear error anyway.

## Quick Start: Cursor one-click install button

Added the Cursor deeplink install button at the top of Quick Start (not in the badge row — its 28-32px height clashes with shields.io's 20px). Placed as a primary CTA above the existing "Or for Claude Desktop, in 30 seconds:" manual flow.

```markdown
[Install in Cursor button]

Or for Claude Desktop, in 30 seconds: ...
```

### Cursor deeplink shape

```json
{
  "command": "uvx",
  "args": ["intervals-icu-mcp"],
  "env": {
    "INTERVALS_ICU_API_KEY": "",
    "INTERVALS_ICU_ATHLETE_ID": ""
  }
}
```

Encoded as base64 and embedded in `cursor://anysphere.cursor-deeplink/mcp/install?name=intervals-icu&config=...`.

Env values are intentionally empty so Cursor's install dialog prompts the user — avoids the foot-gun where someone clicks Install without reading and ends up with literal `your-api-key-here` placeholder strings in their config. Env var names match exactly what `auth.py` reads (`INTERVALS_ICU_API_KEY`, `INTERVALS_ICU_ATHLETE_ID`).

### Caveat

The Cursor deeplink silently fails for visitors without Cursor installed (browsers don't know what `cursor://` means). Standard convention — non-Cursor users skip the button and read the Claude Desktop flow below.

Single-file README change; no code or behavior impact.