### PR TITLE
fix(readme): use cursor.com HTTPS install URL so badge actually triggers deeplink

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Quick Start
 
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-light.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=intervals-icu&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJpbnRlcnZhbHMtaWN1LW1jcCJdLCJlbnYiOnsiSU5URVJWQUxTX0lDVV9BUElfS0VZIjoiIiwiSU5URVJWQUxTX0lDVV9BVEhMRVRFX0lEIjoiIn19)
+<a href="https://cursor.com/en/install-mcp?name=intervals-icu&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJpbnRlcnZhbHMtaWN1LW1jcCJdLCJlbnYiOnsiSU5URVJWQUxTX0lDVV9BUElfS0VZIjoiIiwiSU5URVJWQUxTX0lDVV9BVEhMRVRFX0lEIjoiIn19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/deeplink/mcp-install-dark.svg"><img alt="Install in Cursor" src="https://cursor.com/deeplink/mcp-install-light.svg"></picture></a>
 
 Or for Claude Desktop, in 30 seconds:
 


### PR DESCRIPTION
The Cursor install button merged in #60 was using the raw \`cursor://anysphere.cursor-deeplink/mcp/install?...\` URL as the link target. **GitHub's markdown sanitizer strips link \`href\`s with non-HTTP(S) custom schemes**, so the badge silently became inert — clicking it just opened the camo-proxied SVG image instead of triggering Cursor.

## Fix

Switch to Cursor's HTTPS redirect URL (passes GitHub's link-scheme allowlist), which server-side-redirects to the \`cursor://\` deeplink. Verified working format against a real MCP server's README (\`f2c-ai/f2c-mcp\`).

\`\`\`diff
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-light.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=intervals-icu&config=BASE64_JSON)
+<a href=\"https://cursor.com/install-mcp?name=intervals-icu&config=BASE64_URLENCODED_JSON\">
+  <picture>
+    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cursor.com/deeplink/mcp-install-dark.svg\">
+    <img alt=\"Install in Cursor\" src=\"https://cursor.com/deeplink/mcp-install-light.svg\">
+  </picture>
+</a>
\`\`\`

## Encoding shape

The HTTPS endpoint expects \`config\` as **URL-encoded JSON, then base64-encoded** (not the plain base64-of-JSON form we used before). Verified by reverse-engineering working badges in production. Generated locally with:

\`\`\`bash
JSON='{\"command\":\"uvx\",\"args\":[\"intervals-icu-mcp\"],\"env\":{\"INTERVALS_ICU_API_KEY\":\"\",\"INTERVALS_ICU_ATHLETE_ID\":\"\"}}'
URLENC=\$(python3 -c \"import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))\" \"\$JSON\")
B64=\$(printf '%s' \"\$URLENC\" | base64 | tr -d '\\n')
\`\`\`

## Bonus polish

Also added a \`<picture>\` element with \`prefers-color-scheme\` so GitHub serves \`mcp-install-dark.svg\` to dark-theme viewers and \`mcp-install-light.svg\` to light-theme viewers. Single line, no impact on functionality.

## How to verify after merge

In a terminal:

\`\`\`bash
open 'https://cursor.com/install-mcp?name=intervals-icu&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMnV2eCUyMiUyQyUyMmFyZ3MlMjIlM0ElNUIlMjJpbnRlcnZhbHMtaWN1LW1jcCUyMiU1RCUyQyUyMmVudiUyMiUzQSU3QiUyMklOVEVSVkFMU19JQ1VfQVBJX0tFWSUyMiUzQSUyMiUyMiUyQyUyMklOVEVSVkFMU19JQ1VfQVRITEVURV9JRCUyMiUzQSUyMiUyMiU3RCU3RA%3D%3D'
\`\`\`

Should redirect to Cursor's MCP install dialog with \`uvx intervals-icu-mcp\` pre-filled and empty env fields for API key + athlete ID.

Single-file README change; no code impact. Worth a quick patch release after merge so the live PyPI / MCP Registry README shows the fix.