### PR TITLE
feat: multi-tenant credentials via per-request HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Multi-tenant credentials via per-request HTTP headers.** Over an HTTP transport, each request can carry `X-Intervals-Api-Key` and `X-Intervals-Athlete-Id` headers, letting a single deploy serve multiple athletes. Resolution is per request with priority header → env-var fallback; absent headers preserve the existing env-var (and stdio) behavior unchanged. Headers are layered onto `ICUConfig` by the new `apply_header_credentials()` in `auth.py`, applied in `ConfigMiddleware` (tool calls) and the `intervals-icu://athlete/profile` resource. Backwards compatible (additive). See README *Multi-tenant* and `docs/architecture.md`.
 - `icu_get_activity_details` now surfaces a dedicated `nutrition` section grouping `calories_burned`, `carbs_ingested_g`, and `carbs_used_g`. `carbs_used` is a new field on the `Activity` model (was previously dropped on the floor). The `_g` suffix on carb fields signals grams (matching the wellness-side `carbohydrates_g` convention).
 - `icu_get_activity_details` now emits `metadata.subjective_scales` (`{"feel": "1-5", "rpe": "1-10"}`) whenever the corresponding values are present, so downstream LLMs stop interpreting raw ordinals on an assumed 0-10 scale.
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,18 @@ intervals-icu-mcp --transport sse --host 127.0.0.1 --port 8000
 > - **Reverse proxy with auth** (nginx + basic auth, Cloudflare Access, etc.) — terminates TLS and gates access.
 > - **SSH tunnel** — `ssh -L 8000:localhost:8000 host` if you just need occasional access from one machine.
 >
-> Credentials are always read from `INTERVALS_ICU_API_KEY` and `INTERVALS_ICU_ATHLETE_ID` — use env vars (not a committed `.env`) when deploying to a shared host.
+> Credentials default to `INTERVALS_ICU_API_KEY` and `INTERVALS_ICU_ATHLETE_ID` — use env vars (not a committed `.env`) when deploying to a shared host.
+
+### Multi-tenant (per-request credentials)
+
+Over an HTTP transport, each request can carry its own credentials via headers, so a single deploy can serve many athletes:
+
+| Header | Overrides |
+|---|---|
+| `X-Intervals-Api-Key` | `INTERVALS_ICU_API_KEY` |
+| `X-Intervals-Athlete-Id` | `INTERVALS_ICU_ATHLETE_ID` |
+
+Headers take priority and are resolved **per request**; when absent, the server falls back to the env vars (so stdio and single-tenant setups are unchanged). The same security warning above applies — terminate TLS and authenticate at a proxy, and treat these headers as secrets. See [docs/architecture.md](docs/architecture.md) for details.
 
 ## Usage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,9 @@ Detailed component documentation for the Intervals.icu MCP server.
 ## Middleware (`middleware.py`)
 
 - `ConfigMiddleware` runs before every tool call
-- Loads and validates Intervals.icu configuration from environment
+- Loads Intervals.icu configuration from environment, then applies per-request
+  HTTP header overrides (see [Multi-tenant credentials](#multi-tenant-credentials))
+- Validates the resolved configuration
 - Injects `ICUConfig` into context state via `ctx.set_state("config", config)`
 - Tools access config via `ctx.get_state("config")`
 
@@ -35,8 +37,34 @@ Detailed component documentation for the Intervals.icu MCP server.
 
 1. User runs `uv run intervals-icu-mcp-auth` to set up credentials
 2. Credentials stored in `.env` file (API key + athlete ID)
-3. `ConfigMiddleware` loads and validates on every tool call
+3. `ConfigMiddleware` resolves and validates credentials on every tool call
 4. `ICUClient` uses Basic Auth with username "API_KEY"
+
+### Multi-tenant credentials
+
+Credentials are resolved **per request**, so a single HTTP deployment can serve
+multiple athletes. `apply_header_credentials()` (in `auth.py`) layers per-request
+HTTP headers on top of the env-var-derived `ICUConfig`:
+
+| Header (case-insensitive) | Overrides config field |
+|---|---|
+| `X-Intervals-Api-Key` | `intervals_icu_api_key` |
+| `X-Intervals-Athlete-Id` | `intervals_icu_athlete_id` |
+
+Resolution priority is **header → env var fallback**. A present, non-empty header
+wins; absent or empty headers leave the env value in place. `intervals_icu_delete_mode`
+is a startup/env concern and is never affected by headers.
+
+Headers are read via FastMCP's `get_http_headers()`, which returns `{}` for
+non-HTTP transports (e.g. stdio) and never raises — so stdio and single-tenant
+env-only setups behave exactly as before. The resolution happens in
+`ConfigMiddleware` for tool calls, and inline in the
+`intervals-icu://athlete/profile` resource (resources bypass middleware).
+
+The per-tool `athlete_id` parameter still composes on top of this: the header sets
+the request's *default* athlete, while an explicit `athlete_id` argument can still
+target another athlete (coach access). Treat these headers as secrets and only
+expose the HTTP transport behind TLS + authentication (see the README security note).
 
 ## Response Builder (`response_builder.py`)
 

--- a/src/intervals_icu_mcp/auth.py
+++ b/src/intervals_icu_mcp/auth.py
@@ -1,6 +1,7 @@
 """Authentication and configuration management for Intervals.icu API."""
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal
 
@@ -10,6 +11,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DeleteMode = Literal["safe", "full", "none"]
 VALID_DELETE_MODES: tuple[DeleteMode, ...] = ("safe", "full", "none")
+
+# Per-request HTTP headers that override env-var credentials, enabling a single
+# deploy to serve multiple athletes. Compared case-insensitively.
+HEADER_API_KEY = "x-intervals-api-key"
+HEADER_ATHLETE_ID = "x-intervals-athlete-id"
 
 
 class ICUConfig(BaseSettings):
@@ -48,6 +54,32 @@ def load_config() -> ICUConfig:
     """
     load_dotenv()
     return ICUConfig()
+
+
+def apply_header_credentials(config: ICUConfig, headers: Mapping[str, str]) -> ICUConfig:
+    """Override credentials from per-request HTTP headers, falling back to ``config``.
+
+    Header values take priority over the env-var-derived ``config``. Absent or
+    empty-string headers leave the corresponding value untouched. Header-name
+    lookup is case-insensitive. ``intervals_icu_delete_mode`` is never affected.
+
+    Args:
+        config: Base configuration (typically loaded from env vars).
+        headers: Incoming request headers (e.g. from ``get_http_headers()``).
+
+    Returns:
+        An ICUConfig with header overrides applied, or ``config`` unchanged when
+        no relevant headers are present.
+    """
+    lowered = {key.lower(): value for key, value in headers.items()}
+    updates: dict[str, str] = {}
+    api_key = lowered.get(HEADER_API_KEY)
+    athlete_id = lowered.get(HEADER_ATHLETE_ID)
+    if api_key:
+        updates["intervals_icu_api_key"] = api_key
+    if athlete_id:
+        updates["intervals_icu_athlete_id"] = athlete_id
+    return config.model_copy(update=updates) if updates else config
 
 
 def validate_credentials(config: ICUConfig) -> bool:

--- a/src/intervals_icu_mcp/middleware.py
+++ b/src/intervals_icu_mcp/middleware.py
@@ -7,9 +7,10 @@ from collections.abc import Callable
 from typing import Any
 
 from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
-from .auth import load_config, validate_credentials
+from .auth import apply_header_credentials, load_config, validate_credentials
 
 
 class ConfigMiddleware(Middleware):
@@ -17,21 +18,29 @@ class ConfigMiddleware(Middleware):
 
     This middleware:
     1. Loads the ICU config from environment variables
-    2. Validates that credentials are properly configured
-    3. Injects the config into the context state for tools to access via ctx.get_state("config")
-    4. Raises ToolError if authentication is not configured
+    2. Overrides credentials from per-request HTTP headers (multi-tenant support)
+    3. Validates that credentials are properly configured
+    4. Injects the config into the context state for tools to access via ctx.get_state("config")
+    5. Raises ToolError if authentication is not configured
     """
 
     async def on_call_tool(self, context: MiddlewareContext, call_next: Callable[..., Any]):
-        """Load and validate config before every tool call."""
-        # Load configuration from environment
-        config = load_config()
+        """Resolve and validate config before every tool call.
+
+        Credentials are resolved per request: ``X-Intervals-Api-Key`` /
+        ``X-Intervals-Athlete-Id`` headers win over env vars. ``get_http_headers()``
+        returns an empty dict for non-HTTP transports (e.g. stdio), so the env-var
+        path is preserved unchanged.
+        """
+        # Load configuration from environment, then apply per-request header overrides
+        config = apply_header_credentials(load_config(), get_http_headers())
 
         # Validate credentials are properly configured
         if not validate_credentials(config):
             raise ToolError(
-                "Intervals.icu credentials not configured. "
-                "Please run 'icu-mcp-auth' to set up authentication."
+                "Intervals.icu credentials not configured. Provide the "
+                "X-Intervals-Api-Key and X-Intervals-Athlete-Id headers, or run "
+                "'icu-mcp-auth' to set up environment credentials."
             )
 
         # Inject config into context state for tools to access

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -643,12 +643,15 @@ if _DELETE_MODE == "full":
 @mcp.resource("intervals-icu://athlete/profile")
 async def athlete_profile_resource() -> str:
     """Complete athlete profile with fitness metrics and sport settings for context."""
-    from .auth import load_config
+    from fastmcp.server.dependencies import get_http_headers
+
+    from .auth import apply_header_credentials, load_config
     from .client import ICUAPIError, ICUClient
     from .response_builder import ResponseBuilder
 
-    # Load config directly since resources don't go through middleware
-    config = load_config()
+    # Resources don't go through middleware, so resolve credentials here too:
+    # env vars as the base, overridden by per-request headers (multi-tenant).
+    config = apply_header_credentials(load_config(), get_http_headers())
 
     try:
         async with ICUClient(config) as client:

--- a/tests/test_header_credentials.py
+++ b/tests/test_header_credentials.py
@@ -1,0 +1,77 @@
+"""Unit tests for per-request header credential resolution.
+
+These cover the pure resolution helper that lets a single deploy serve multiple
+athletes: ``X-Intervals-Api-Key`` / ``X-Intervals-Athlete-Id`` headers override
+the env-var-derived config, with env values as fallback.
+"""
+
+from intervals_icu_mcp.auth import ICUConfig, apply_header_credentials
+
+
+def _base_config() -> ICUConfig:
+    return ICUConfig(
+        intervals_icu_api_key="env_key",
+        intervals_icu_athlete_id="i_env",
+        intervals_icu_delete_mode="full",
+    )
+
+
+class TestApplyHeaderCredentials:
+    def test_headers_override_env(self):
+        result = apply_header_credentials(
+            _base_config(),
+            {"x-intervals-api-key": "hdr_key", "x-intervals-athlete-id": "i_hdr"},
+        )
+        assert result.intervals_icu_api_key == "hdr_key"
+        assert result.intervals_icu_athlete_id == "i_hdr"
+
+    def test_no_headers_falls_back_to_env(self):
+        result = apply_header_credentials(_base_config(), {})
+        assert result.intervals_icu_api_key == "env_key"
+        assert result.intervals_icu_athlete_id == "i_env"
+
+    def test_only_api_key_header(self):
+        result = apply_header_credentials(
+            _base_config(), {"x-intervals-api-key": "hdr_key"}
+        )
+        assert result.intervals_icu_api_key == "hdr_key"
+        assert result.intervals_icu_athlete_id == "i_env"  # env fallback
+
+    def test_only_athlete_id_header(self):
+        result = apply_header_credentials(
+            _base_config(), {"x-intervals-athlete-id": "i_hdr"}
+        )
+        assert result.intervals_icu_api_key == "env_key"  # env fallback
+        assert result.intervals_icu_athlete_id == "i_hdr"
+
+    def test_empty_header_values_are_ignored(self):
+        result = apply_header_credentials(
+            _base_config(),
+            {"x-intervals-api-key": "", "x-intervals-athlete-id": ""},
+        )
+        assert result.intervals_icu_api_key == "env_key"
+        assert result.intervals_icu_athlete_id == "i_env"
+
+    def test_header_lookup_is_case_insensitive(self):
+        result = apply_header_credentials(
+            _base_config(),
+            {"X-Intervals-Api-Key": "hdr_key", "X-INTERVALS-ATHLETE-ID": "i_hdr"},
+        )
+        assert result.intervals_icu_api_key == "hdr_key"
+        assert result.intervals_icu_athlete_id == "i_hdr"
+
+    def test_returns_icu_config_and_preserves_delete_mode(self):
+        result = apply_header_credentials(
+            _base_config(), {"x-intervals-api-key": "hdr_key"}
+        )
+        assert isinstance(result, ICUConfig)
+        # delete_mode is a startup/env concern and must not be touched by headers
+        assert result.intervals_icu_delete_mode == "full"
+
+    def test_does_not_mutate_input_config(self):
+        config = _base_config()
+        apply_header_credentials(
+            config, {"x-intervals-api-key": "hdr_key", "x-intervals-athlete-id": "i_hdr"}
+        )
+        assert config.intervals_icu_api_key == "env_key"
+        assert config.intervals_icu_athlete_id == "i_env"

--- a/tests/test_middleware_integration.py
+++ b/tests/test_middleware_integration.py
@@ -99,3 +99,77 @@ class TestMiddlewareIntegration:
         async with Client(server) as client:
             with pytest.raises(ToolError, match="credentials"):
                 await client.call_tool("dummy_tool")
+
+
+class TestHeaderCredentialResolution:
+    """Test per-request header overrides through the real middleware pipeline.
+
+    The in-memory transport has no HTTP layer, so we patch the middleware's
+    ``get_http_headers`` to simulate incoming request headers.
+    """
+
+    async def test_headers_override_env_credentials(
+        self, integration_server, monkeypatch
+    ):
+        """X-Intervals-* headers take priority over the configured env vars."""
+        monkeypatch.setattr(
+            "intervals_icu_mcp.middleware.get_http_headers",
+            lambda *a, **k: {
+                "x-intervals-api-key": "header_key",
+                "x-intervals-athlete-id": "i_header",
+            },
+        )
+
+        async with Client(integration_server) as client:
+            result = await client.call_tool("inspect_config")
+            data = json.loads(result.data)
+
+            assert data["api_key"] == "header_key"
+            assert data["athlete_id"] == "i_header"
+
+    async def test_env_used_when_no_headers(self, integration_server, monkeypatch):
+        """Without headers, the env-var fallback (from the fixture) is used."""
+        monkeypatch.setattr(
+            "intervals_icu_mcp.middleware.get_http_headers",
+            lambda *a, **k: {},
+        )
+
+        async with Client(integration_server) as client:
+            result = await client.call_tool("inspect_config")
+            data = json.loads(result.data)
+
+            assert data["api_key"] == "test_api_key_integration"
+            assert data["athlete_id"] == "i999999"
+
+    async def test_header_only_provides_credentials(self, monkeypatch):
+        """Headers alone satisfy validation even when env credentials are absent."""
+        monkeypatch.setenv("INTERVALS_ICU_API_KEY", "")
+        monkeypatch.setenv("INTERVALS_ICU_ATHLETE_ID", "")
+        monkeypatch.setenv("ENV_FILE", "/dev/null")
+        monkeypatch.setattr(
+            "intervals_icu_mcp.middleware.get_http_headers",
+            lambda *a, **k: {
+                "x-intervals-api-key": "header_key",
+                "x-intervals-athlete-id": "i_header",
+            },
+        )
+
+        server = FastMCP("header-only")
+        server.add_middleware(ConfigMiddleware())
+
+        @server.tool()
+        async def inspect_config(ctx: Context) -> str:
+            config = await ctx.get_state("config")
+            return json.dumps(
+                {
+                    "api_key": config.intervals_icu_api_key,
+                    "athlete_id": config.intervals_icu_athlete_id,
+                }
+            )
+
+        async with Client(server) as client:
+            result = await client.call_tool("inspect_config")
+            data = json.loads(result.data)
+
+            assert data["api_key"] == "header_key"
+            assert data["athlete_id"] == "i_header"


### PR DESCRIPTION
Resolve Intervals.icu credentials per request so a single HTTP deploy can serve multiple athletes. X-Intervals-Api-Key and X-Intervals-Athlete-Id headers override the env-var-derived config (priority: header -> env fallback). Absent headers preserve existing stdio/single-tenant behavior.

Adds apply_header_credentials() in auth.py, applied in ConfigMiddleware and the athlete/profile resource. Backwards compatible.

https://claude.ai/code/session_01Udwi5EfuKzNw9guTewmDZL

## Summary

<!-- What does this PR do, and why? If it closes an issue, write "Closes #123". -->

## Changes

<!-- A short bulleted list of the concrete changes. -->

-
-

## Checklist

- [ ] `make can-release` passes locally (tests, ruff, pyright)
- [ ] New tools have a corresponding respx-mocked test file in `tests/`
- [ ] Public-facing behavior changes are reflected in the README or `docs/`
- [ ] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [ ] No API keys, athlete IDs, or other credentials are committed

## Test plan

<!-- How did you verify the change? e.g. unit tests added, tested live against a Claude Desktop session, etc. -->
