### PR TITLE
chore(release): 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] — 2026-06-18
+
 ### Added
 - `icu_get_activity_details` now surfaces a dedicated `nutrition` section grouping `calories_burned`, `carbs_ingested_g`, and `carbs_used_g`. `carbs_used` is a new field on the `Activity` model (was previously dropped on the floor). The `_g` suffix on carb fields signals grams (matching the wellness-side `carbohydrates_g` convention).
 - `icu_get_activity_details` now emits `metadata.subjective_scales` (`{"feel": "1-5", "rpe": "1-10"}`) whenever the corresponding values are present, so downstream LLMs stop interpreting raw ordinals on an assumed 0-10 scale.


### PR DESCRIPTION
Cut the v4.0.0 release.

Renames CHANGELOG `[Unreleased]` → `[4.0.0] — 2026-06-18`. The release bundles the nutrition section work (#59) including the breaking `calories` → `calories_burned` response-shape rename, plus `metadata.subjective_scales`.

After merge: tag `v4.0.0` and create the GitHub Release (triggers PyPI + MCP Registry publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)