### PR TITLE
fix(publish): trim server.json description under registry 100-char limit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   mcp-registry:
     needs: pypi

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.hhopke/intervals-icu-mcp",
-  "description": "Read/write Intervals.icu MCP server — 55+ tools across activities, streams, wellness, calendar, gear, and sport zones, plus structured workout generation for cycling, running, and swimming.",
+  "description": "Read/write Intervals.icu MCP server: activities, wellness, calendar, gear, and workouts.",
   "repository": {
     "url": "https://github.com/hhopke/intervals-icu-mcp",
     "source": "github"


### PR DESCRIPTION
The v4.0.0 release published to PyPI successfully but **failed the MCP Registry step**: `server.json` `description` was ~190 chars and the registry caps it at 100 (HTTP 422, `expected length <= 100`).

- Trim `description` to 88 chars.
- Add `skip-existing: true` to the PyPI publish step so a re-run of `publish.yml` after a partial failure doesn't die on the already-published version (which would skip the `needs: pypi` registry job).

The v4.0.0 registry entry itself is being published manually out-of-band, since the failed CI run is pinned to the pre-fix commit and can't pick up this change on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)