### PR TITLE
Add icu_get_activities_by_date tool and fix activities-around HTTP 422

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Intervals.icu — provides up to 59 tools, 4 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 56 tools; `full` registers all 59, `none` registers 53.
+MCP (Model Context Protocol) server for Intervals.icu — provides up to 60 tools, 4 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 57 tools; `full` registers all 60, `none` registers 54.
 
 - **Language**: Python 3.11+
 - **Framework**: FastMCP

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-59 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 4 MCP Resources (athlete profile, workout syntax, event categories, custom item schemas) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
+60 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 4 MCP Resources (athlete profile, workout syntax, event categories, custom item schemas) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
 
 ## Quick Start
 
@@ -213,7 +213,7 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 
 ## Available Tools
 
-59 tools, 4 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
+60 tools, 4 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
 
 | Category | Tools | Summary |
 |---|---|---|

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool, Resource, and Prompt Reference
 
-Complete inventory of everything the Intervals.icu MCP server exposes: up to 59 tools across 11 categories, 4 MCP Resources, and 7 MCP Prompts.
+Complete inventory of everything the Intervals.icu MCP server exposes: up to 60 tools across 11 categories, 4 MCP Resources, and 7 MCP Prompts.
 
 ## Delete Safety Mode
 
@@ -8,9 +8,9 @@ Destructive tools are gated by the optional `INTERVALS_ICU_DELETE_MODE` env var.
 
 | Mode | Registered tools | Events | Activities | Gear | Sport settings | Custom items |
 |---|---|---|---|---|---|---|
-| `safe` (default) | 56 | tomorrow or later | ✗ | ✓ | ✗ | ✗ |
-| `full` | 59 | any date | ✓ | ✓ | ✓ | ✓ |
-| `none` | 53 | ✗ | ✗ | ✗ | ✗ | ✗ |
+| `safe` (default) | 57 | tomorrow or later | ✗ | ✓ | ✗ | ✗ |
+| `full` | 60 | any date | ✓ | ✓ | ✓ | ✓ |
+| `none` | 54 | ✗ | ✗ | ✗ | ✗ | ✗ |
 
 In `safe` mode, `icu_delete_event` and `icu_bulk_delete_events` return a uniform envelope showing what was deleted and what was skipped:
 
@@ -48,11 +48,12 @@ Set the mode in your client config alongside the credentials:
 
 ## Tools
 
-### Activities (12 tools)
+### Activities (13 tools)
 
 | Tool                     | Description                                       |
 | ------------------------ | ------------------------------------------------- |
 | `icu_get_recent_activities`  | List recent activities with summary metrics       |
+| `icu_get_activities_by_date` | List activities in an explicit date window (oldest..newest) |
 | `icu_get_activity_details`   | Get comprehensive details for a specific activity |
 | `icu_search_activities`      | Search activities by name or tag                  |
 | `icu_search_activities_full` | Search activities with full details               |

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -260,7 +260,9 @@ class ICUClient:
             List of Activity objects around the reference activity
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {"id": activity_id, "count": count}
+        # The API expects query params `activity_id` and `limit` (not `id`/`count`);
+        # sending the wrong names yields HTTP 422 "Required request parameter 'activity_id'".
+        params = {"activity_id": activity_id, "limit": count}
 
         response = await self._request(
             "GET", f"/athlete/{athlete_id}/activities-around", params=params

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -32,6 +32,7 @@ from .tools.activities import (
     download_fit_file,
     download_gpx_file,
     get_activities_around,
+    get_activities_by_date,
     get_activity_details,
     get_recent_activities,
     search_activities,
@@ -99,6 +100,15 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(get_recent_activities)
+mcp.tool(
+    name="icu_get_activities_by_date",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(get_activities_by_date)
 mcp.tool(
     name="icu_get_activity_details",
     annotations={

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -11,6 +11,47 @@ from ..response_builder import ResponseBuilder
 from ._strava import strava_limitation_note
 
 
+def _summarize_activity(activity: Any) -> dict[str, Any]:
+    """Build a LIGHT summary dict for one activity.
+
+    Shared by the recent-activities and date-range listing tools so both
+    emit an identical item shape.
+    """
+    item: dict[str, Any] = {
+        "id": activity.id,
+        "name": activity.name or "Untitled",
+        "start_date": activity.start_date_local,
+        "type": activity.type,
+    }
+
+    if activity.distance:
+        item["distance_meters"] = activity.distance
+
+    if activity.moving_time:
+        item["moving_time_seconds"] = activity.moving_time
+
+    if activity.total_elevation_gain:
+        item["elevation_gain_meters"] = activity.total_elevation_gain
+
+    # Performance metrics
+    if activity.average_watts:
+        item["average_watts"] = activity.average_watts
+    if activity.normalized_power:
+        item["normalized_power"] = activity.normalized_power
+    if activity.average_heartrate:
+        item["average_heartrate"] = activity.average_heartrate
+    if activity.average_cadence:
+        item["average_cadence"] = activity.average_cadence
+
+    # Training load
+    if activity.icu_training_load:
+        item["training_load"] = activity.icu_training_load
+    if activity.icu_intensity:
+        item["intensity_factor"] = activity.icu_intensity
+
+    return item
+
+
 async def get_recent_activities(
     limit: Annotated[int, "Number of activities to fetch"] = 30,
     days_back: Annotated[int, "Number of days to look back"] = 30,
@@ -44,45 +85,65 @@ async def get_recent_activities(
                     metadata={"message": "No activities found"},
                 )
 
-            activities_data: list[dict[str, Any]] = []
-            for activity in activities:
-                activity_item: dict[str, Any] = {
-                    "id": activity.id,
-                    "name": activity.name or "Untitled",
-                    "start_date": activity.start_date_local,
-                    "type": activity.type,
-                }
-
-                if activity.distance:
-                    activity_item["distance_meters"] = activity.distance
-
-                if activity.moving_time:
-                    activity_item["moving_time_seconds"] = activity.moving_time
-
-                if activity.total_elevation_gain:
-                    activity_item["elevation_gain_meters"] = activity.total_elevation_gain
-
-                # Performance metrics
-                if activity.average_watts:
-                    activity_item["average_watts"] = activity.average_watts
-                if activity.normalized_power:
-                    activity_item["normalized_power"] = activity.normalized_power
-                if activity.average_heartrate:
-                    activity_item["average_heartrate"] = activity.average_heartrate
-                if activity.average_cadence:
-                    activity_item["average_cadence"] = activity.average_cadence
-
-                # Training load
-                if activity.icu_training_load:
-                    activity_item["training_load"] = activity.icu_training_load
-                if activity.icu_intensity:
-                    activity_item["intensity_factor"] = activity.icu_intensity
-
-                activities_data.append(activity_item)
+            activities_data = [_summarize_activity(a) for a in activities]
 
             return ResponseBuilder.build_response(
                 data={"activities": activities_data, "count": len(activities_data)},
                 query_type="recent_activities",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def get_activities_by_date(
+    oldest: Annotated[str, "Oldest date to include, YYYY-MM-DD (inclusive)"],
+    newest: Annotated[
+        str | None, "Newest date to include, YYYY-MM-DD (inclusive). Defaults to today."
+    ] = None,
+    limit: Annotated[
+        int, "Max activities to return (newest-first within the window)"
+    ] = 500,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """List activities within an EXPLICIT date window (oldest..newest) — LIGHT summary per item.
+
+    Unlike icu_get_recent_activities (anchored to today and capped at 100), this
+    targets an arbitrary historical window and is bounded only by `limit`. Use for
+    "all my runs from June to November 2025", reconstructing training history, or
+    finding the oldest activity in a period. Dates are YYYY-MM-DD. Results are
+    newest-first; if a window holds more than `limit` items, the oldest are
+    dropped first, so widen `limit` (or narrow the window) to reach the very
+    oldest.
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            activities = await client.get_activities(
+                athlete_id=athlete_id,
+                oldest=oldest,
+                newest=newest,
+                limit=limit,
+            )
+
+            if not activities:
+                return ResponseBuilder.build_response(
+                    data={"activities": [], "count": 0},
+                    metadata={"message": "No activities found in the given date range"},
+                )
+
+            activities_data = [_summarize_activity(a) for a in activities]
+
+            return ResponseBuilder.build_response(
+                data={"activities": activities_data, "count": len(activities_data)},
+                query_type="activities_by_date",
             )
 
     except ICUAPIError as e:

--- a/tests/test_activities_by_date.py
+++ b/tests/test_activities_by_date.py
@@ -1,0 +1,118 @@
+"""Date-range activity listing + the activities-around query-param fix.
+
+These complement test_activities_read_tools.py. The around tests here assert
+the *outgoing query parameters* (not just the path), which is what the
+HTTP 422 fix is about — the API requires `activity_id`/`limit`, not `id`/`count`.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.activities import (
+    get_activities_around,
+    get_activities_by_date,
+)
+
+
+def _make_ctx(mock_config):
+    ctx = MagicMock()
+    ctx.get_state = AsyncMock(return_value=mock_config)
+    return ctx
+
+
+class TestGetActivitiesByDate:
+    async def test_success_with_full_metrics(self, mock_config, respx_mock):
+        respx_mock.get("/athlete/i123456/activities").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": "a1",
+                        "name": "Evening Run",
+                        "start_date_local": "2025-11-12T19:08:13",
+                        "type": "Run",
+                        "distance": 9600,
+                        "moving_time": 2764,
+                        "average_heartrate": 150,
+                        "icu_training_load": 60,
+                        "icu_intensity": 0.97,
+                    },
+                    {
+                        "id": "a2",
+                        "name": None,  # Untitled fallback
+                        "start_date_local": "2025-06-03T07:00:00",
+                        "type": "Ride",
+                    },
+                ],
+            )
+        )
+
+        result = await get_activities_by_date(
+            oldest="2025-06-01", newest="2025-11-30", ctx=_make_ctx(mock_config)
+        )
+
+        response = json.loads(result)
+        assert response["data"]["count"] == 2
+        first = response["data"]["activities"][0]
+        assert first["training_load"] == 60
+        assert first["intensity_factor"] == 0.97
+        assert response["data"]["activities"][1]["name"] == "Untitled"
+
+    async def test_sends_oldest_and_newest_params(self, mock_config, respx_mock):
+        respx_mock.get("/athlete/i123456/activities").mock(
+            return_value=Response(200, json=[])
+        )
+
+        await get_activities_by_date(
+            oldest="2025-06-01", newest="2025-11-30", ctx=_make_ctx(mock_config)
+        )
+
+        params = respx_mock.calls.last.request.url.params
+        assert params["oldest"] == "2025-06-01"
+        assert params["newest"] == "2025-11-30"
+
+    async def test_newest_optional(self, mock_config, respx_mock):
+        respx_mock.get("/athlete/i123456/activities").mock(
+            return_value=Response(200, json=[])
+        )
+
+        await get_activities_by_date(oldest="2025-06-01", ctx=_make_ctx(mock_config))
+
+        params = respx_mock.calls.last.request.url.params
+        assert params["oldest"] == "2025-06-01"
+        assert "newest" not in params
+
+    async def test_empty(self, mock_config, respx_mock):
+        respx_mock.get("/athlete/i123456/activities").mock(
+            return_value=Response(200, json=[])
+        )
+
+        result = await get_activities_by_date(
+            oldest="2025-06-01", ctx=_make_ctx(mock_config)
+        )
+        response = json.loads(result)
+        assert response["data"]["count"] == 0
+        assert "No activities found" in response["metadata"]["message"]
+
+
+class TestActivitiesAroundParams:
+    """Regression guard for the HTTP 422 fix: correct query-param names."""
+
+    async def test_sends_activity_id_and_limit_not_id_count(self, mock_config, respx_mock):
+        respx_mock.get("/athlete/i123456/activities-around").mock(
+            return_value=Response(200, json=[])
+        )
+
+        await get_activities_around(
+            activity_id="i159947305", count=30, ctx=_make_ctx(mock_config)
+        )
+
+        params = respx_mock.calls.last.request.url.params
+        # The fix: API-correct names are sent...
+        assert params["activity_id"] == "i159947305"
+        assert params["limit"] == "30"
+        # ...and the old wrong names are gone.
+        assert "id" not in params
+        assert "count" not in params

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -31,10 +31,10 @@ class TestInMemoryTransport:
             assert client.is_connected()
 
     async def test_all_default_mode_tools_registered(self):
-        """Default delete_mode=safe registers 56 tools (3 destructive tools gated)."""
+        """Default delete_mode=safe registers 57 tools (3 destructive tools gated)."""
         async with Client(mcp) as client:
             tools = await client.list_tools()
-            assert len(tools) == 56
+            assert len(tools) == 57
             names = {t.name for t in tools}
             # Spot-check tools from different modules / tiers
             assert "icu_get_recent_activities" in names
@@ -192,5 +192,5 @@ class TestHTTPTransport:
                 tools_body = (await tools_resp.aread()).decode()
                 tools_payload = self._parse_sse_response(tools_body)
                 tool_names = {t["name"] for t in tools_payload["result"]["tools"]}
-                assert len(tool_names) == 56  # safe mode default
+                assert len(tool_names) == 57  # safe mode default
                 assert "icu_get_recent_activities" in tool_names


### PR DESCRIPTION
## What & why

Two related changes to the activity-read layer.

### Fix: `icu_get_activities_around` returns HTTP 422
The client sent query params `id` and `count`, but per the OpenAPI spec the
`/athlete/{id}/activities-around` endpoint expects `activity_id` and `limit`.
The call failed with `422 Required request parameter 'activity_id' is not present`.
Corrected the param names in `client.py`.

### Feature: new `icu_get_activities_by_date` tool
`icu_get_recent_activities` is anchored to "today" and capped at 100 items, so
arbitrary historical windows are unreachable. The underlying API (and the client's
`get_activities`) already support `oldest`/`newest` date params — they just weren't
surfaced at the tool layer. This adds a tool exposing an explicit date window
(`oldest`/`newest`, YYYY-MM-DD), bounded only by `limit`.

## Changes
- `tools/activities.py`: new `get_activities_by_date`; extracted shared
  `_summarize_activity` helper (used by both recent + date-range listings).
- `client.py`: fix `get_activities_around` query params.
- `server.py`: register `icu_get_activities_by_date`.
- `tests/test_activities_by_date.py`: 5 tests asserting the outgoing query params
  (the gap that let the 422 slip through — existing tests only matched the path).

## Tests
All activity-related suites green (50 passing), including the new file.