### PR TITLE
ci(test): run tests on pull_request events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - main
+  pull_request:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## What

Adds a `pull_request` trigger to the Test workflow, alongside the existing `push` and `workflow_call` triggers.

## Why

The Test workflow previously only ran on `push` to non-`main` branches. Fork contributors push to their own fork, so that event never fires here — community PRs (e.g. #73, #74) arrived with **no CI at all**. This closes that gap so every PR reports pass/fail before merge.

`pull_request` also tests the **merge result** (PR head merged into `main`), which is a more accurate "will it pass when we merge" signal than the branch-in-isolation `push` run.

## Notes

- Tests need no secrets (HTTP is mocked with `respx`), so this is safe for fork PRs on a public repo — they run with the read-only `GITHUB_TOKEN`.
- First-time fork contributors will hit the standard **"Approve and run"** gate before CI runs; auto-runs on subsequent pushes after one approval.
- Existing open PRs (#73, #74) need a rebase/reopen to pick up the new trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)