### PR TITLE
perf(client): pass limit query param to activities endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `icu_get_annual_training_plan` tool — reads Annual Training Plan (ATP) periodization from the calendar: weekly load targets (TSS), Base/Build/Peak phase blocks, and recovery-week notes, shaped from `PLAN`/`TARGET`/`NOTE` events. Defaults to a 365-day forward window; narrow with `days_ahead`/`days_back`. Safe-mode tool count goes 55 → 56 (58 → 59 in full mode). Contributed by @jorge-huxley (#73).
 - The `Event` model now retains `load_target`, `time_target`, and `tags` from the API (previously dropped during validation).
 
+### Changed
+- `client.get_activities()` now passes `limit` to the API as a query param instead of fetching the entire date range and truncating client-side. Verified against the live API that server-side `limit` keeps the newest N in descending order — identical results, far less data over the wire for wide date windows (#80).
+
 ### Fixed
 - ATP weeks starting on a shared phase-boundary date (e.g. Base ends and Build starts on the same day) are now assigned to the newer phase (#73).
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -160,7 +160,7 @@ class ICUClient:
             List of ActivitySummary objects
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, str | int] = {"limit": limit}
 
         if oldest:
             params["oldest"] = oldest
@@ -171,7 +171,8 @@ class ICUClient:
         adapter = TypeAdapter(list[ActivitySummary])
         activities = adapter.validate_python(response.json())
 
-        # Limit results
+        # The server applies `limit` to the desc-ordered result (newest N kept, same as
+        # this slice); the slice stays as a safety net in case the server returns more.
         return activities[:limit]
 
     async def get_activity(self, athlete_id: str | None = None, activity_id: str = "") -> Activity:

--- a/tests/test_activities_read_tools.py
+++ b/tests/test_activities_read_tools.py
@@ -77,9 +77,20 @@ class TestGetRecentActivities:
         assert response["data"]["count"] == 0
         assert "No activities found" in response["metadata"]["message"]
 
+    async def test_sends_limit_and_date_params(self, mock_config, respx_mock):
+        """The API's native limit param is sent, so the server truncates — not the client."""
+        respx_mock.get("/athlete/i123456/activities").mock(return_value=Response(200, json=[]))
+
+        await get_recent_activities(limit=10, days_back=7, ctx=_make_ctx(mock_config))
+
+        params = respx_mock.calls.last.request.url.params
+        assert params["limit"] == "10"
+        assert "oldest" in params
+
     async def test_limit_capped_at_100(self, mock_config, respx_mock):
-        """Tool caps limit at 100 even if user asks for more — slicing is client-side."""
-        # Server returns 150 results; client.get_activities slices to 100
+        """Tool caps limit at 100 even if user asks for more."""
+        # Server-side limit does the real truncation; the client-side slice is a
+        # safety net, exercised here by a mock that ignores the limit param.
         many = [
             {
                 "id": f"a{i}",


### PR DESCRIPTION
## Summary

Closes #80.

`client.get_activities()` fetched the entire date-range result set and truncated client-side with `activities[:limit]`, even though the `listActivities` endpoint supports a native `limit` query param. For wide historical windows this pulled every activity over the wire and discarded most of them.

## Changes

- `client.py`: send `limit` as a query param; the client-side slice stays as a safety net
- `tests/test_activities_read_tools.py`: new test asserting the outgoing `limit`/`oldest` query params; updated the cap test's comment to reflect that the mock (which ignores `limit`) now exercises the safety-net slice
- `CHANGELOG.md`: entry under `[Unreleased]` → Changed

## Semantics verification

Checked against the live API before changing anything: `GET .../activities?oldest=…&newest=…&limit=3` returns exactly the same IDs as slicing the unlimited desc-ordered response to 3 — server-side `limit` keeps the newest N, matching the previous client-side behavior and the tool docstrings ("oldest are dropped first").

Benefits all callers: `icu_get_recent_activities`, `icu_search_activities`, and `icu_get_activities_by_date` from #74 once it rebases.

## Test plan

- `make can-release` green (267 passed, ruff/pyright/pyroma clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)