### PR TITLE
fix(workout-syntax): document meters as mtr and yards as yrd, not bare m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Event` model now retains `load_target`, `time_target`, and `tags` from the API (previously dropped during validation).
 
 ### Fixed
+- Corrected the distance units in the `intervals-icu://workout-syntax` resource: meters are `mtr` (e.g. `400mtr`) and yards are `yrd`, not the ambiguous `m`/`yd`. Intervals.icu parses a bare `m` as **minutes**, so the previous docs led LLMs to write `400m` for a 400 m swim step — parsed as 400 minutes, producing wildly inflated durations and distances (a 2500 m swim came out as ~417 km / ~41 h). All swim/run examples now use `mtr`, and a note spells out the `m`-means-minutes rule (#75).
 - ATP weeks starting on a shared phase-boundary date (e.g. Base ends and Build starts on the same day) are now assigned to the newer phase (#73).
 
 ## [4.0.0] — 2026-06-18

--- a/src/intervals_icu_mcp/workout_syntax.py
+++ b/src/intervals_icu_mcp/workout_syntax.py
@@ -54,8 +54,8 @@ Or standalone repeat:
 
 ```
 Intervals 5x
-- 400m 110% pace
-- 400m Z1
+- 400mtr 110% pace
+- 400mtr Z1
 ```
 
 **Important**: Leave a blank line before and after repeat blocks.
@@ -76,10 +76,13 @@ Intervals 5x
 ### Distance-Based
 | Format | Example | Description |
 |--------|---------|-------------|
-| `Xm` | `400m` | Meters (context-dependent, >200 = meters) |
+| `Xmtr` | `400mtr` | Meters (swimming/running) |
 | `Xkm` | `5km` | Kilometers |
 | `Xmi` | `3mi` | Miles |
-| `Xyd` | `100yd` | Yards (swimming) |
+| `Xyrd` | `100yrd` | Yards (swimming) |
+
+**Important**: Plain `m` always means **minutes**, never meters. For a distance
+in meters use `mtr` (e.g. `400mtr`) — writing `400m` is parsed as 400 minutes.
 
 ### Lap Press
 ```
@@ -154,8 +157,8 @@ Text before the duration becomes a device prompt or instruction:
 ## Rest Intervals
 Rest can be specified after the main target:
 ```
-- 200m 95% pace 30s rest
-- 100m Z4 20s rest
+- 200mtr 95% pace 30s rest
+- 100mtr Z4 20s rest
 ```
 
 ## Complete Examples
@@ -204,11 +207,11 @@ Cooldown
 ```
 Warmup
 - 15m Z2 HR
-- 4x 100m strides
+- 4x 100mtr strides
 
 Main Set 5x
-- 800m 105-110% pace
-- 400m Z1 HR
+- 800mtr 105-110% pace
+- 400mtr Z1 HR
 
 Cooldown
 - 10m Z1 HR
@@ -217,14 +220,14 @@ Cooldown
 ### Swimming - CSS Training
 ```
 Warmup
-- 400m Z2 pace
-- 4x 50m 85% pace
+- 400mtr Z2 pace
+- 4x 50mtr 85% pace
 
 Main Set 5x
-- 200m 95% pace 30s rest
+- 200mtr 95% pace 30s rest
 
 Cooldown
-- 200m Z1 pace
+- 200mtr Z1 pace
 ```
 
 ## Zone Reference

--- a/tests/test_workout_syntax.py
+++ b/tests/test_workout_syntax.py
@@ -1,0 +1,46 @@
+"""Regression tests for the workout syntax reference (intervals-icu://workout-syntax).
+
+The Intervals.icu parser treats a bare ``m`` suffix as **minutes**, never
+meters — so a distance step must use ``mtr`` (meters) or ``yrd`` (yards).
+Writing ``400m`` for a 400 m swim is parsed as 400 *minutes*, which is what
+produced the ~41-hour / hundreds-of-km garbage reported in issue #75.
+"""
+
+import re
+
+from intervals_icu_mcp.workout_syntax import WORKOUT_SYNTAX_SPEC
+
+
+def test_meters_token_is_mtr_not_bare_m():
+    """The distance table documents meters as ``mtr``, not the ambiguous ``m``."""
+    assert "400mtr" in WORKOUT_SYNTAX_SPEC
+    # The old, incorrect "context-dependent, >200 = meters" heuristic is gone.
+    assert "context-dependent" not in WORKOUT_SYNTAX_SPEC
+
+
+def test_yards_token_is_yrd_not_yd():
+    """Yards use ``yrd`` (verified against the API); ``yd`` is not a valid token."""
+    assert "yrd" in WORKOUT_SYNTAX_SPEC
+    assert "yd" not in WORKOUT_SYNTAX_SPEC.replace("yrd", "")
+
+
+def test_minutes_vs_meters_warning_present():
+    """The spec explicitly warns that bare ``m`` means minutes."""
+    assert "never meters" in WORKOUT_SYNTAX_SPEC
+
+
+def test_no_example_step_uses_bare_m_for_distance():
+    """No worked example writes a swim/run distance as a bare ``m`` step.
+
+    Matches only step lines (``- ...``, optionally with an ``Nx`` repeat
+    prefix such as ``- 4x 100m strides``) for the distance values we
+    converted. Anchoring to the line start skips prose like the
+    ``### Running - 800m Repeats`` heading, and the trailing ``\\b`` skips
+    the corrected ``400mtr`` tokens. Pure time steps like ``- 20m ... pace``
+    (20 minutes) are unaffected — 20 is not a converted distance.
+    """
+    for meters in (50, 100, 200, 400, 800):
+        pattern = rf"^- (?:\d+x )?{meters}m\b"
+        assert not re.search(pattern, WORKOUT_SYNTAX_SPEC, re.MULTILINE), (
+            f"Found bare-metre distance step '- {meters}m' — use '{meters}mtr' instead"
+        )


### PR DESCRIPTION
## Summary

The `intervals-icu://workout-syntax` resource documented a distance in **meters** as `400m` and **yards** as `100yd`. But Intervals.icu parses a bare `m` suffix as **minutes**, so an LLM following the resource writes `400m` for a 400 m swim step — which the API reads as 400 *minutes*. The result is wildly inflated durations and distances: the reporter's 2,500 m swim came out as ~113 km over ~41 h.

Closes #75.

## Changes

- `src/intervals_icu_mcp/workout_syntax.py`:
  - Distance table now documents meters as `Xmtr` / `400mtr` and yards as `Xyrd` / `100yrd`.
  - Removed the fictional "context-dependent, >200 = meters" rule (Intervals.icu has no such heuristic).
  - Added an explicit note that a bare `m` always means minutes; `/100m` pace denominators are left intact.
  - Converted every swim/run example step from bare `m` to `mtr`.
- `tests/test_workout_syntax.py`: new regression guard — meters = `mtr`, yards = `yrd`, the minutes note is present, and no worked example reintroduces a bare-`m` distance step.
- `CHANGELOG.md`: entry under `### Fixed` in `[Unreleased]`.

Not a SemVer-relevant change: no tool response shape, parameters, or defaults change — this corrects the content of a documentation resource. Patch-level fix.

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/` (n/a — no new tools; added `tests/test_workout_syntax.py`)
- [x] Public-facing behavior changes are reflected in the README or `docs/` (CHANGELOG updated; resource content is self-documenting)
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate (n/a — no new tools)
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

- `make can-release` green: 270 tests, ruff, pyright all pass.
- Verified end-to-end against the live Intervals.icu API (not just mocks). Using the exact workout from #75:
  - `400m` / `100m` steps → `duration_seconds` 150,000 (2,500 minutes), `distance_meters` in the hundreds of km — reproducing the bug.
  - `400mtr` / `100mtr` steps → `duration_seconds` 900 (15 min), `distance_meters` 2,500.0 — correct.
  - Test events were created on a future date and deleted afterward.
