### PR TITLE
docs(release): narrow SemVer contract to integration-breaking changes

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -47,7 +47,7 @@ For `feat`, `fix`, or anything user-visible, check whether docs need updating in
   - `CLAUDE.md` (project overview line stating tool counts)
   - `docs/tools.md` if the registered set changed
 - **README discipline** — keep `README.md` under 300 lines. If a new section would push past ~30 lines and isn't core onboarding, extract it to `docs/` and link from the README.
-- **SemVer flag** — if the change alters a response shape, removes a tool/parameter, or changes a default that drops tools (e.g. `INTERVALS_ICU_DELETE_MODE`), call it out in the PR body — this requires a major version bump per CLAUDE.md.
+- **SemVer flag** — if the change removes or renames a tool/parameter, changes config env var semantics, changes default tool registration (e.g. `INTERVALS_ICU_DELETE_MODE`), or removes information from a response, call it out in the PR body — this requires a major version bump per CLAUDE.md. Response-shape changes that preserve the information (key renames, restructuring, added fields) are minor, not breaking.
 - **Do not reference upstream/comparison repos** in commit messages, PR bodies, CHANGELOG, or README.
 
 ## Pre-PR gate — MANDATORY before opening a PR

--- a/.claude/skills/release-write/SKILL.md
+++ b/.claude/skills/release-write/SKILL.md
@@ -65,12 +65,12 @@ Adopt these conventions:
 
 **MCP-specific framing for response-shape changes:**
 
-This project's CLAUDE.md treats response-shape changes as breaking → major bump. Honor that. But the *user impact* in MCP context is smaller than in SDK context:
+Per the narrowed SemVer contract (CHANGELOG header, adopted after 4.0.0), information-preserving response-shape changes (key renames, restructuring, added fields) are **minor**, not breaking. Only tool/parameter removals or renames, config env var semantic changes, default-registration changes, and removal of information from responses force a major. The reasoning:
 - MCP responses are consumed by LLMs that rephrase into natural language.
 - Programmatic parsers (`response["data"]["field"]`) are rare in MCP usage.
 - A field rename usually doesn't break user-visible behavior; the LLM adapts.
 
-So when a release breaks response shape, the release-notes treatment should be proportional to the actual user impact: **one paragraph of inline upgrade prose, not an SDK-style Migration section with before/after diff blocks**. Diff blocks are for projects where consumers write typed parsing code; they're overkill here.
+When a release does include a breaking change — or a notable shape change worth flagging — keep the release-notes treatment proportional to the actual user impact: **one paragraph of inline upgrade prose, not an SDK-style Migration section with before/after diff blocks**. Diff blocks are for projects where consumers write typed parsing code; they're overkill here.
 
 Don't:
 - Rewrite the CHANGELOG verbatim. The CHANGELOG is comprehensive; the release notes are curated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+**The versioned contract covers what breaks integrations:** removing or renaming a
+tool, removing or renaming a tool parameter, changing the meaning of a config env
+var, changing which tools register by default, or removing information from a
+response. Any of these requires a **major** bump. Response payload *shape* changes
+that preserve the information (key renames, restructuring, added fields) ship in
+**minor** releases — MCP responses are read dynamically by LLMs, not parsed by typed
+clients. (Releases up to and including 4.0.0 treated any response-shape change as
+breaking; this narrower contract applies from the next release onward.)
+
 ## [Unreleased]
 
 ### Added
@@ -12,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Event` model now retains `load_target`, `time_target`, and `tags` from the API (previously dropped during validation).
 
 ### Changed
+- Versioning policy: the SemVer contract is narrowed to what breaks integrations — tool names, tool parameters, config env var semantics, default tool registration, and removal of information from responses. Response-shape changes that preserve information (key renames, restructuring, added fields) are now **minor**, not major. See the header above. Previously any response-shape change forced a major bump.
 - `client.get_activities()` now passes `limit` to the API as a query param instead of fetching the entire date range and truncating client-side. Verified against the live API that server-side `limit` keeps the newest N in descending order — identical results, far less data over the wire for wide date windows (#80).
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ To cut a release:
 2. Commit (e.g., `chore(release): X.Y.Z`)
 3. Tag and push: `git tag vX.Y.Z && git push origin main vX.Y.Z`
 
-Follow strict SemVer — breaking changes (response shape changes, default-behavior changes that remove tools, removed parameters) require a major bump. The CHANGELOG header explicitly commits to SemVer.
+Follow SemVer with the narrowed contract defined in the CHANGELOG header. **Major** (breaking): removing or renaming a tool or tool parameter, changing config env var semantics, changing which tools register by default, or removing information from a response. **Minor**: response-shape changes that preserve the information (key renames, restructuring, added fields) — MCP responses are read dynamically by LLMs, not parsed by typed clients. Releases ≤ 4.0.0 predate this policy and treated any response-shape change as breaking.
 
 ## Important Files
 


### PR DESCRIPTION
## Summary

Narrows the project's SemVer contract to the surface that actually breaks integrations. Previously any response-shape change forced a major bump, which produced three majors in under two months (2.0.0 → 4.0.0) — two of them for changes with little real-world impact (3.0.0's histogram shape change fixed tools that previously crashed outright; 4.0.0 was a pure output-key rename).

Under the new contract, a **major** bump is required for: removing or renaming a tool or tool parameter, changing config env var semantics, changing default tool registration, or removing information from a response. Response payload shape changes that preserve the information (key renames, restructuring, added fields) are **minor** — MCP responses here are plain text content blocks read dynamically by LLMs (tools return `str`, no `outputSchema` is declared), not a machine-readable schema parsed by typed clients.

The policy applies from the next release onward; releases ≤ 4.0.0 are not retroactively reinterpreted. If evidence of programmatic shape-parsing consumers appears, or the server ever adopts MCP `outputSchema`/`structuredContent`, the contract should be widened again.

## Changes

- `CHANGELOG.md` — header now defines the versioned contract explicitly; added an `[Unreleased]` → Changed entry documenting the policy switch
- `CLAUDE.md` — Releases section: replaced the strict "response shape = breaking" rule with the narrowed major/minor split
- `.claude/skills/commit/SKILL.md` — SemVer PR-body flag now fires only for the narrowed breaking set
- `.claude/skills/release-write/SKILL.md` — release-notes framing updated to match; proportional upgrade-prose guidance unchanged

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/` (n/a — docs/policy only)
- [x] Public-facing behavior changes are reflected in the README or `docs/` (CHANGELOG header is the public statement of the policy)
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate (n/a)
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

Docs/policy-only change — no runtime surface. `make can-release` (ruff, pyright, pytest, coverage gate, packaging checks) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)