### PR TITLE
fix(sport-settings): expose indoor_ftp and align API field mapping

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -100,7 +100,7 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 ```
 "Update my FTP to 275 watts"
 "Set my indoor FTP to 260 watts"
-"Show my current zone settings for cycling"
+"Show my current FTP and thresholds for cycling"
 "Set my running threshold pace to 4:30 per kilometer"
 "Apply my new threshold settings to historical activities"
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -99,6 +99,7 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 
 ```
 "Update my FTP to 275 watts"
+"Set my indoor FTP to 260 watts"
 "Show my current zone settings for cycling"
 "Set my running threshold pace to 4:30 per kilometer"
 "Apply my new threshold settings to historical activities"

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -92,7 +92,7 @@ The threaded notes/comments shown under an activity — the user's own training 
 
 | Tool                  | Description                                                     |
 | --------------------- | --------------------------------------------------------------- |
-| `icu_get_athlete_profile` | Get athlete profile with fitness metrics and sport settings     |
+| `icu_get_athlete_profile` | Get athlete profile, fitness metrics, and outdoor/indoor FTP   |
 | `icu_get_fitness_summary` | Get detailed CTL/ATL/TSB analysis with training recommendations |
 
 ### Wellness (3 tools)
@@ -150,7 +150,7 @@ The threaded notes/comments shown under an activity — the user's own training 
 | Tool                    | Description                                             |
 | ----------------------- | ------------------------------------------------------- |
 | `icu_get_sport_settings`    | Get sport-specific settings and thresholds              |
-| `icu_update_sport_settings` | Update FTP, FTHR, pace threshold, or zone configuration |
+| `icu_update_sport_settings` | Update outdoor/indoor FTP, FTHR, pace threshold, or zone configuration |
 | `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
 | `icu_create_sport_settings` | Create new sport-specific settings                      |
 | `icu_delete_sport_settings` | Delete sport-specific settings *(only registered when `INTERVALS_ICU_DELETE_MODE=full`; deletion shifts retroactive chart math)* |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -150,8 +150,8 @@ The threaded notes/comments shown under an activity — the user's own training 
 | Tool                    | Description                                             |
 | ----------------------- | ------------------------------------------------------- |
 | `icu_get_sport_settings`    | Get sport-specific settings and thresholds              |
-| `icu_update_sport_settings` | Update outdoor/indoor FTP, FTHR, pace threshold, or zone configuration |
-| `icu_apply_sport_settings`  | Apply updated settings to historical activities         |
+| `icu_update_sport_settings` | Update outdoor/indoor FTP, FTHR, or pace/swim thresholds |
+| `icu_apply_sport_settings`  | Recompute historical activity metrics from current sport settings |
 | `icu_create_sport_settings` | Create new sport-specific settings                      |
 | `icu_delete_sport_settings` | Delete sport-specific settings *(only registered when `INTERVALS_ICU_DELETE_MODE=full`; deletion shifts retroactive chart math)* |
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -1101,6 +1101,8 @@ class ICUClient:
         sport_id: int,
         settings_data: dict[str, Any],
         athlete_id: str | None = None,
+        *,
+        recalc_hr_zones: bool = True,
     ) -> SportSettings:
         """Update sport-specific settings (FTP, FTHR, pace threshold, etc.).
 
@@ -1108,39 +1110,37 @@ class ICUClient:
             sport_id: Sport settings ID
             settings_data: Updated settings data dictionary
             athlete_id: Athlete ID (uses config default if not provided)
+            recalc_hr_zones: Whether Intervals.icu should recalculate HR zones
 
         Returns:
             Updated SportSettings object
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
         response = await self._request(
-            "PUT", f"/athlete/{athlete_id}/sport-settings/{sport_id}", json=settings_data
+            "PUT",
+            f"/athlete/{athlete_id}/sport-settings/{sport_id}",
+            params={"recalcHrZones": recalc_hr_zones},
+            json=settings_data,
         )
         return SportSettings(**response.json())
 
     async def apply_sport_settings(
         self,
         sport_id: int,
-        oldest: str | None = None,
         athlete_id: str | None = None,
     ) -> dict[str, Any]:
         """Apply sport settings (zones, thresholds) to historical activities.
 
         Args:
             sport_id: Sport settings ID
-            oldest: Oldest date to apply settings to (ISO-8601 format)
             athlete_id: Athlete ID (uses config default if not provided)
 
         Returns:
             Result of applying settings
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
-        if oldest:
-            params["oldest"] = oldest
-
         response = await self._request(
-            "POST", f"/athlete/{athlete_id}/sport-settings/{sport_id}/apply", params=params
+            "PUT", f"/athlete/{athlete_id}/sport-settings/{sport_id}/apply"
         )
         return response.json()
 

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -37,6 +37,7 @@ class SportSettings(BaseModel):
     id: int
     type: str | None = None
     ftp: int | None = None
+    indoor_ftp: int | None = None
     fthr: int | None = None
     pace_threshold: float | None = None
     swim_threshold: float | None = None

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for Intervals.icu API responses."""
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
@@ -56,22 +56,25 @@ class SportSettings(BaseModel):
         if not isinstance(data, dict):
             return data
 
-        normalized = dict(data)
-        types = normalized.get("types")
-        if isinstance(types, list) and types and not normalized.get("type"):
+        raw = cast(dict[str, Any], data)
+        normalized: dict[str, Any] = dict(raw)
+        types = raw.get("types")
+        if isinstance(types, list) and types and normalized.get("type") is None:
             normalized["type"] = types[0]
 
-        if normalized.get("lthr") is not None and normalized.get("fthr") is None:
-            normalized["fthr"] = normalized["lthr"]
+        if raw.get("lthr") is not None and normalized.get("fthr") is None:
+            normalized["fthr"] = raw["lthr"]
 
-        threshold_pace = normalized.get("threshold_pace")
+        threshold_pace = raw.get("threshold_pace")
         if threshold_pace is not None:
-            pace_load_type = normalized.get("pace_load_type")
-            pace_units = normalized.get("pace_units") or ""
-            sport_types = types if isinstance(types, list) else []
-            is_swim = pace_load_type == "SWIM" or any(t in _SWIM_SPORT_TYPES for t in sport_types)
+            pace_load_type = raw.get("pace_load_type")
+            pace_units = raw.get("pace_units") or ""
+            sport_types = cast(list[Any], types) if isinstance(types, list) else []
+            is_swim = pace_load_type == "SWIM" or any(
+                isinstance(t, str) and t in _SWIM_SPORT_TYPES for t in sport_types
+            )
             if is_swim:
-                if pace_units in _SWIM_PACE_UNITS_SECONDS:
+                if isinstance(pace_units, str) and pace_units in _SWIM_PACE_UNITS_SECONDS:
                     normalized["swim_threshold"] = threshold_pace / 60.0
                 elif normalized.get("swim_threshold") is None:
                     normalized["swim_threshold"] = threshold_pace

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 # Type aliases for common enums
 ActivityType = Literal["Ride", "Run", "Swim", "Walk", "Hike", "VirtualRide", "VirtualRun", "Other"]
@@ -30,9 +30,16 @@ TrainingAvailability = Literal["NORMAL", "LIMITED", "UNAVAILABLE"]
 
 # ==================== Athlete Models ====================
 
+_SWIM_SPORT_TYPES = frozenset({"Swim", "OpenWaterSwim"})
+_SWIM_PACE_UNITS_SECONDS = frozenset(
+    {"SECS_100M", "SECS_100Y", "SECS_500M", "SECS_400M", "SECS_250M"}
+)
+
 
 class SportSettings(BaseModel):
     """Sport-specific settings for an athlete."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: int
     type: str | None = None
@@ -42,9 +49,42 @@ class SportSettings(BaseModel):
     pace_threshold: float | None = None
     swim_threshold: float | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_api_fields(cls, data: Any) -> Any:
+        """Map Intervals.icu SportSettings JSON to MCP field names."""
+        if not isinstance(data, dict):
+            return data
+
+        normalized = dict(data)
+        types = normalized.get("types")
+        if isinstance(types, list) and types and not normalized.get("type"):
+            normalized["type"] = types[0]
+
+        if normalized.get("lthr") is not None and normalized.get("fthr") is None:
+            normalized["fthr"] = normalized["lthr"]
+
+        threshold_pace = normalized.get("threshold_pace")
+        if threshold_pace is not None:
+            pace_load_type = normalized.get("pace_load_type")
+            pace_units = normalized.get("pace_units") or ""
+            sport_types = types if isinstance(types, list) else []
+            is_swim = pace_load_type == "SWIM" or any(t in _SWIM_SPORT_TYPES for t in sport_types)
+            if is_swim:
+                if pace_units in _SWIM_PACE_UNITS_SECONDS:
+                    normalized["swim_threshold"] = threshold_pace / 60.0
+                elif normalized.get("swim_threshold") is None:
+                    normalized["swim_threshold"] = threshold_pace
+            elif normalized.get("pace_threshold") is None:
+                normalized["pace_threshold"] = threshold_pace
+
+        return normalized
+
 
 class Athlete(BaseModel):
     """Full athlete profile information."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str
     name: str
@@ -57,7 +97,10 @@ class Athlete(BaseModel):
     atl: float | None = None
     tsb: float | None = None
     ramp_rate: float | None = None
-    sport_settings: list[SportSettings] = Field(default_factory=list[SportSettings])
+    sport_settings: list[SportSettings] = Field(
+        default_factory=list[SportSettings],
+        validation_alias=AliasChoices("sport_settings", "sportSettings"),
+    )
 
 
 class AthleteProfile(BaseModel):

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -699,6 +699,8 @@ async def athlete_profile_resource() -> str:
                     }
                     if sport.ftp:
                         sport_info["ftp"] = sport.ftp
+                    if sport.indoor_ftp is not None:
+                        sport_info["indoor_ftp"] = sport.indoor_ftp
                     if sport.fthr:
                         sport_info["fthr"] = sport.fthr
                     if sport.pace_threshold:

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -666,6 +666,7 @@ async def athlete_profile_resource() -> str:
     from .auth import load_config
     from .client import ICUAPIError, ICUClient
     from .response_builder import ResponseBuilder
+    from .sport_settings_format import format_sport_settings_entry
 
     # Load config directly since resources don't go through middleware
     config = load_config()
@@ -692,21 +693,10 @@ async def athlete_profile_resource() -> str:
 
             # Add sport settings if available
             if athlete.sport_settings:
-                sport_data: list[dict[str, str | int | float | None]] = []
-                for sport in athlete.sport_settings:
-                    sport_info: dict[str, str | int | float | None] = {
-                        "type": sport.type,
-                    }
-                    if sport.ftp:
-                        sport_info["ftp"] = sport.ftp
-                    if sport.indoor_ftp is not None:
-                        sport_info["indoor_ftp"] = sport.indoor_ftp
-                    if sport.fthr:
-                        sport_info["fthr"] = sport.fthr
-                    if sport.pace_threshold:
-                        sport_info["threshold_pace"] = sport.pace_threshold
-                    sport_data.append(sport_info)
-                data["sports"] = sport_data
+                data["sports"] = [
+                    format_sport_settings_entry(sport, include_id=False)
+                    for sport in athlete.sport_settings
+                ]
 
             return ResponseBuilder.build_response(data, metadata={"type": "athlete_profile"})
     except ICUAPIError as e:

--- a/src/intervals_icu_mcp/sport_settings_format.py
+++ b/src/intervals_icu_mcp/sport_settings_format.py
@@ -1,0 +1,65 @@
+"""Format sport settings for MCP responses and Intervals.icu API write payloads."""
+
+from typing import Any
+
+from .models import SportSettings
+
+
+def format_sport_settings_entry(
+    settings: SportSettings,
+    *,
+    include_id: bool = True,
+) -> dict[str, Any]:
+    """Build an LLM-facing sport settings dict with consistent unit suffixes."""
+    sport_info: dict[str, Any] = {}
+    if include_id:
+        sport_info["id"] = settings.id
+    if settings.type is not None:
+        sport_info["type"] = settings.type
+    if settings.ftp is not None:
+        sport_info["ftp_watts"] = settings.ftp
+    if settings.indoor_ftp is not None:
+        sport_info["indoor_ftp_watts"] = settings.indoor_ftp
+    if settings.fthr is not None:
+        sport_info["fthr_bpm"] = settings.fthr
+    if settings.pace_threshold is not None:
+        pace_secs = settings.pace_threshold * 60
+        minutes = int(pace_secs // 60)
+        seconds = int(pace_secs % 60)
+        sport_info["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
+    if settings.swim_threshold is not None:
+        swim_secs = settings.swim_threshold * 60
+        minutes = int(swim_secs // 60)
+        seconds = int(swim_secs % 60)
+        sport_info["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
+    return sport_info
+
+
+def build_sport_settings_api_payload(
+    *,
+    sport_type: str | None = None,
+    ftp: int | None = None,
+    indoor_ftp: int | None = None,
+    fthr: int | None = None,
+    pace_threshold: float | None = None,
+    swim_threshold: float | None = None,
+) -> dict[str, Any]:
+    """Convert MCP tool parameters to Intervals.icu SportSettings JSON field names."""
+    payload: dict[str, Any] = {}
+    if sport_type is not None:
+        payload["types"] = [sport_type]
+    if ftp is not None:
+        payload["ftp"] = ftp
+    if indoor_ftp is not None:
+        payload["indoor_ftp"] = indoor_ftp
+    if fthr is not None:
+        payload["lthr"] = fthr
+    if pace_threshold is not None:
+        payload["threshold_pace"] = pace_threshold
+        payload["pace_units"] = "MINS_KM"
+        payload["pace_load_type"] = "RUN"
+    if swim_threshold is not None:
+        payload["threshold_pace"] = swim_threshold * 60
+        payload["pace_units"] = "SECS_100M"
+        payload["pace_load_type"] = "SWIM"
+    return payload

--- a/src/intervals_icu_mcp/sport_settings_format.py
+++ b/src/intervals_icu_mcp/sport_settings_format.py
@@ -45,6 +45,13 @@ def build_sport_settings_api_payload(
     swim_threshold: float | None = None,
 ) -> dict[str, Any]:
     """Convert MCP tool parameters to Intervals.icu SportSettings JSON field names."""
+    if pace_threshold is not None and swim_threshold is not None:
+        raise ValueError(
+            "Cannot set pace_threshold and swim_threshold in the same call; "
+            "the API stores one pace threshold per sport settings record. "
+            "Use separate calls for Run and Swim settings."
+        )
+
     payload: dict[str, Any] = {}
     if sport_type is not None:
         payload["types"] = [sport_type]

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -13,7 +13,7 @@ from ..response_builder import ResponseBuilder
 async def get_athlete_profile(
     ctx: Context | None = None,
 ) -> str:
-    """Get the authenticated athlete's profile — personal details, sport settings (FTP/FTHR/pace thresholds per sport), and current CTL/ATL/TSB with form interpretation."""
+    """Get the authenticated athlete's profile — sport settings (outdoor/indoor FTP, FTHR, pace) and current CTL/ATL/TSB."""
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
 
@@ -56,6 +56,8 @@ async def get_athlete_profile(
                         sport_data["type"] = sport.type
                     if sport.ftp:
                         sport_data["ftp"] = sport.ftp
+                    if sport.indoor_ftp is not None:
+                        sport_data["indoor_ftp"] = sport.indoor_ftp
                     if sport.fthr:
                         sport_data["fthr"] = sport.fthr
                     if sport.pace_threshold:

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from ..sport_settings_format import format_sport_settings_entry
 
 
 async def get_athlete_profile(
@@ -51,23 +52,7 @@ async def get_athlete_profile(
             sports: list[dict[str, Any]] = []
             if athlete.sport_settings:
                 for sport in athlete.sport_settings:
-                    sport_data: dict[str, Any] = {}
-                    if sport.type:
-                        sport_data["type"] = sport.type
-                    if sport.ftp:
-                        sport_data["ftp"] = sport.ftp
-                    if sport.indoor_ftp is not None:
-                        sport_data["indoor_ftp"] = sport.indoor_ftp
-                    if sport.fthr:
-                        sport_data["fthr"] = sport.fthr
-                    if sport.pace_threshold:
-                        sport_data["pace_threshold_seconds"] = sport.pace_threshold
-                        minutes = int(sport.pace_threshold // 60)
-                        seconds = int(sport.pace_threshold % 60)
-                        sport_data["pace_threshold_formatted"] = f"{minutes}:{seconds:02d} /km"
-                    if sport.swim_threshold:
-                        sport_data["swim_threshold"] = sport.swim_threshold
-                    sports.append(sport_data)
+                    sports.append(format_sport_settings_entry(sport, include_id=False))
 
             data: dict[str, Any] = {
                 "profile": profile,

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -12,7 +12,7 @@ from ..response_builder import ResponseBuilder
 async def get_sport_settings(
     ctx: Context | None = None,
 ) -> str:
-    """Get all per-sport thresholds — FTP (cycling watts), FTHR (heart rate), pace threshold (running), swim threshold."""
+    """Get all per-sport thresholds — outdoor/indoor FTP, FTHR, running pace, and swim threshold."""
     config = load_config()
     if not validate_credentials(config):
         return (
@@ -39,6 +39,8 @@ async def get_sport_settings(
                 # Power settings (cycling)
                 if settings.ftp is not None:
                     sport_info["ftp_watts"] = settings.ftp
+                if settings.indoor_ftp is not None:
+                    sport_info["indoor_ftp_watts"] = settings.indoor_ftp
 
                 # Heart rate settings
                 if settings.fthr is not None:
@@ -75,6 +77,9 @@ async def get_sport_settings(
 async def update_sport_settings(
     sport_id: Annotated[int, "ID of the sport settings to update"],
     ftp: Annotated[int | None, "Functional Threshold Power in watts (for cycling)"] = None,
+    indoor_ftp: Annotated[
+        int | None, "Indoor Functional Threshold Power in watts (for cycling)"
+    ] = None,
     fthr: Annotated[int | None, "Functional Threshold Heart Rate in bpm"] = None,
     pace_threshold: Annotated[
         float | None, "Threshold pace in min/km (e.g., 4.5 for 4:30/km)"
@@ -84,7 +89,7 @@ async def update_sport_settings(
     ] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Update an existing per-sport threshold record (FTP/FTHR/pace/swim). Only fields you pass are sent."""
+    """Update an existing per-sport threshold record (outdoor/indoor FTP, FTHR, pace, swim)."""
     config = load_config()
     if not validate_credentials(config):
         return (
@@ -97,6 +102,8 @@ async def update_sport_settings(
 
             if ftp is not None:
                 settings_data["ftp"] = ftp
+            if indoor_ftp is not None:
+                settings_data["indoor_ftp"] = indoor_ftp
             if fthr is not None:
                 settings_data["fthr"] = fthr
             if pace_threshold is not None:
@@ -118,6 +125,8 @@ async def update_sport_settings(
 
             if settings.ftp is not None:
                 result["ftp_watts"] = settings.ftp
+            if settings.indoor_ftp is not None:
+                result["indoor_ftp_watts"] = settings.indoor_ftp
             if settings.fthr is not None:
                 result["fthr_bpm"] = settings.fthr
             if settings.pace_threshold is not None:
@@ -184,6 +193,9 @@ async def apply_sport_settings(
 async def create_sport_settings(
     sport_type: Annotated[str, "Type of sport (e.g., 'Ride', 'Run', 'Swim')"],
     ftp: Annotated[int | None, "Functional Threshold Power in watts (for cycling)"] = None,
+    indoor_ftp: Annotated[
+        int | None, "Indoor Functional Threshold Power in watts (for cycling)"
+    ] = None,
     fthr: Annotated[int | None, "Functional Threshold Heart Rate in bpm"] = None,
     pace_threshold: Annotated[
         float | None, "Threshold pace in min/km (e.g., 4.5 for 4:30/km)"
@@ -193,7 +205,7 @@ async def create_sport_settings(
     ] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create new per-sport threshold record (FTP/FTHR/pace/swim) for a sport that doesn't have one yet."""
+    """Create a per-sport threshold record with outdoor/indoor FTP, FTHR, pace, or swim settings."""
     config = load_config()
     if not validate_credentials(config):
         return (
@@ -206,6 +218,8 @@ async def create_sport_settings(
 
             if ftp is not None:
                 settings_data["ftp"] = ftp
+            if indoor_ftp is not None:
+                settings_data["indoor_ftp"] = indoor_ftp
             if fthr is not None:
                 settings_data["fthr"] = fthr
             if pace_threshold is not None:
@@ -222,6 +236,8 @@ async def create_sport_settings(
 
             if settings.ftp is not None:
                 result["ftp_watts"] = settings.ftp
+            if settings.indoor_ftp is not None:
+                result["indoor_ftp_watts"] = settings.indoor_ftp
             if settings.fthr is not None:
                 result["fthr_bpm"] = settings.fthr
             if settings.pace_threshold is not None:

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -1,6 +1,6 @@
 """Sport-specific settings tools for FTP, FTHR, pace thresholds, and zones."""
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastmcp import Context
 

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -55,6 +55,9 @@ async def update_sport_settings(
     swim_threshold: Annotated[
         float | None, "Swim threshold in min/100m (e.g., 1.5 for 1:30/100m)"
     ] = None,
+    recalc_hr_zones: Annotated[
+        bool, "Recalculate HR zones from the updated threshold heart rate"
+    ] = True,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing per-sport threshold record (outdoor/indoor FTP, FTHR, pace, swim)."""
@@ -79,7 +82,11 @@ async def update_sport_settings(
                     "No fields provided to update", error_type="validation_error"
                 )
 
-            settings = await client.update_sport_settings(sport_id, settings_data)
+            settings = await client.update_sport_settings(
+                sport_id,
+                settings_data,
+                recalc_hr_zones=recalc_hr_zones,
+            )
 
             return ResponseBuilder.build_response(
                 format_sport_settings_entry(settings),
@@ -97,9 +104,6 @@ async def update_sport_settings(
 
 async def apply_sport_settings(
     sport_id: Annotated[int, "ID of the sport settings to apply"],
-    oldest_date: Annotated[
-        str | None, "Oldest date to apply settings to (YYYY-MM-DD format)"
-    ] = None,
     ctx: Context | None = None,
 ) -> str:
     """Recompute training load, zones, and derived metrics on HISTORICAL activities using the current sport settings.
@@ -115,7 +119,7 @@ async def apply_sport_settings(
 
     try:
         async with ICUClient(config) as client:
-            result = await client.apply_sport_settings(sport_id, oldest=oldest_date)
+            result = await client.apply_sport_settings(sport_id)
 
             return ResponseBuilder.build_response(
                 result,

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -96,6 +96,8 @@ async def update_sport_settings(
                 },
             )
 
+    except ValueError as e:
+        return ResponseBuilder.build_error_response(str(e), error_type="validation_error")
     except ICUAPIError as e:
         return ResponseBuilder.build_error_response(e.message, error_type="api_error")
     except Exception as e:
@@ -178,6 +180,8 @@ async def create_sport_settings(
                 },
             )
 
+    except ValueError as e:
+        return ResponseBuilder.build_error_response(str(e), error_type="validation_error")
     except ICUAPIError as e:
         return ResponseBuilder.build_error_response(e.message, error_type="api_error")
     except Exception as e:

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import load_config, validate_credentials
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from ..sport_settings_format import build_sport_settings_api_payload, format_sport_settings_entry
 
 
 async def get_sport_settings(
@@ -28,40 +29,7 @@ async def get_sport_settings(
                     {"message": "No sport settings found"}, metadata={"count": 0}
                 )
 
-            settings_data: list[dict[str, Any]] = []
-
-            for settings in settings_list:
-                sport_info: dict[str, Any] = {
-                    "id": settings.id,
-                    "type": settings.type,
-                }
-
-                # Power settings (cycling)
-                if settings.ftp is not None:
-                    sport_info["ftp_watts"] = settings.ftp
-                if settings.indoor_ftp is not None:
-                    sport_info["indoor_ftp_watts"] = settings.indoor_ftp
-
-                # Heart rate settings
-                if settings.fthr is not None:
-                    sport_info["fthr_bpm"] = settings.fthr
-
-                # Pace settings (running/swimming)
-                if settings.pace_threshold is not None:
-                    # Convert to min:sec per km
-                    pace_secs = settings.pace_threshold * 60
-                    minutes = int(pace_secs // 60)
-                    seconds = int(pace_secs % 60)
-                    sport_info["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-
-                if settings.swim_threshold is not None:
-                    # Convert to min:sec per 100m
-                    swim_secs = settings.swim_threshold * 60
-                    minutes = int(swim_secs // 60)
-                    seconds = int(swim_secs % 60)
-                    sport_info["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
-
-                settings_data.append(sport_info)
+            settings_data = [format_sport_settings_entry(settings) for settings in settings_list]
 
             return ResponseBuilder.build_response(
                 {"sport_settings": settings_data},
@@ -98,18 +66,13 @@ async def update_sport_settings(
 
     try:
         async with ICUClient(config) as client:
-            settings_data: dict[str, Any] = {}
-
-            if ftp is not None:
-                settings_data["ftp"] = ftp
-            if indoor_ftp is not None:
-                settings_data["indoor_ftp"] = indoor_ftp
-            if fthr is not None:
-                settings_data["fthr"] = fthr
-            if pace_threshold is not None:
-                settings_data["pace_threshold"] = pace_threshold
-            if swim_threshold is not None:
-                settings_data["swim_threshold"] = swim_threshold
+            settings_data = build_sport_settings_api_payload(
+                ftp=ftp,
+                indoor_ftp=indoor_ftp,
+                fthr=fthr,
+                pace_threshold=pace_threshold,
+                swim_threshold=swim_threshold,
+            )
 
             if not settings_data:
                 return ResponseBuilder.build_error_response(
@@ -118,30 +81,8 @@ async def update_sport_settings(
 
             settings = await client.update_sport_settings(sport_id, settings_data)
 
-            result: dict[str, Any] = {
-                "id": settings.id,
-                "type": settings.type,
-            }
-
-            if settings.ftp is not None:
-                result["ftp_watts"] = settings.ftp
-            if settings.indoor_ftp is not None:
-                result["indoor_ftp_watts"] = settings.indoor_ftp
-            if settings.fthr is not None:
-                result["fthr_bpm"] = settings.fthr
-            if settings.pace_threshold is not None:
-                pace_secs = settings.pace_threshold * 60
-                minutes = int(pace_secs // 60)
-                seconds = int(pace_secs % 60)
-                result["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-            if settings.swim_threshold is not None:
-                swim_secs = settings.swim_threshold * 60
-                minutes = int(swim_secs // 60)
-                seconds = int(swim_secs % 60)
-                result["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
-
             return ResponseBuilder.build_response(
-                result,
+                format_sport_settings_entry(settings),
                 metadata={
                     "type": "sport_settings_updated",
                     "message": "Sport settings updated successfully",
@@ -214,45 +155,19 @@ async def create_sport_settings(
 
     try:
         async with ICUClient(config) as client:
-            settings_data: dict[str, Any] = {"type": sport_type}
-
-            if ftp is not None:
-                settings_data["ftp"] = ftp
-            if indoor_ftp is not None:
-                settings_data["indoor_ftp"] = indoor_ftp
-            if fthr is not None:
-                settings_data["fthr"] = fthr
-            if pace_threshold is not None:
-                settings_data["pace_threshold"] = pace_threshold
-            if swim_threshold is not None:
-                settings_data["swim_threshold"] = swim_threshold
+            settings_data = build_sport_settings_api_payload(
+                sport_type=sport_type,
+                ftp=ftp,
+                indoor_ftp=indoor_ftp,
+                fthr=fthr,
+                pace_threshold=pace_threshold,
+                swim_threshold=swim_threshold,
+            )
 
             settings = await client.create_sport_settings(settings_data)
 
-            result: dict[str, Any] = {
-                "id": settings.id,
-                "type": settings.type,
-            }
-
-            if settings.ftp is not None:
-                result["ftp_watts"] = settings.ftp
-            if settings.indoor_ftp is not None:
-                result["indoor_ftp_watts"] = settings.indoor_ftp
-            if settings.fthr is not None:
-                result["fthr_bpm"] = settings.fthr
-            if settings.pace_threshold is not None:
-                pace_secs = settings.pace_threshold * 60
-                minutes = int(pace_secs // 60)
-                seconds = int(pace_secs % 60)
-                result["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-            if settings.swim_threshold is not None:
-                swim_secs = settings.swim_threshold * 60
-                minutes = int(swim_secs // 60)
-                seconds = int(swim_secs % 60)
-                result["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
-
             return ResponseBuilder.build_response(
-                result,
+                format_sport_settings_entry(settings),
                 metadata={
                     "type": "sport_settings_created",
                     "message": "Sport settings created successfully",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,12 +61,12 @@ def mock_athlete_data():
         "atl": 35.0,
         "tsb": 15.0,
         "ramp_rate": 3.5,
-        "sport_settings": [
+        "sportSettings": [
             {
                 "id": 1,
-                "type": "Ride",
+                "types": ["Ride"],
                 "ftp": 250,
-                "fthr": 165,
+                "lthr": 165,
             }
         ],
     }

--- a/tests/test_athlete_branches.py
+++ b/tests/test_athlete_branches.py
@@ -76,23 +76,36 @@ class TestAthleteProfileFormBuckets:
 
 class TestAthleteProfileSportSettings:
     async def test_pace_threshold_formatted(self, mock_config, respx_mock):
-        """Run pace_threshold is rendered as 'M:SS /km' alongside the raw seconds value."""
+        """Run threshold_pace is rendered with the same unit suffixes as sport settings tools."""
         respx_mock.get("/athlete/i123456").mock(
             return_value=Response(
                 200,
                 json={
                     "id": "i123456",
                     "name": "Test",
-                    "sport_settings": [
-                        {"id": 1, "type": "Run", "fthr": 170, "pace_threshold": 240.0},
+                    "sportSettings": [
+                        {
+                            "id": 1,
+                            "types": ["Run"],
+                            "lthr": 170,
+                            "threshold_pace": 4.0,
+                            "pace_units": "MINS_KM",
+                            "pace_load_type": "RUN",
+                        },
                         {
                             "id": 2,
-                            "type": "Ride",
+                            "types": ["Ride"],
                             "ftp": 260,
                             "indoor_ftp": 250,
-                            "fthr": 165,
+                            "lthr": 165,
                         },
-                        {"id": 3, "type": "Swim", "swim_threshold": 95.0},
+                        {
+                            "id": 3,
+                            "types": ["Swim"],
+                            "threshold_pace": 95,
+                            "pace_units": "SECS_100M",
+                            "pace_load_type": "SWIM",
+                        },
                     ],
                 },
             )
@@ -102,13 +115,13 @@ class TestAthleteProfileSportSettings:
         response = json.loads(result)
         sports = response["data"]["sports"]
         run = next(s for s in sports if s["type"] == "Run")
-        assert run["pace_threshold_seconds"] == 240.0
-        assert run["pace_threshold_formatted"] == "4:00 /km"
+        assert run["fthr_bpm"] == 170
+        assert run["pace_threshold"] == "4:00 /km"
         ride = next(s for s in sports if s["type"] == "Ride")
-        assert ride["ftp"] == 260
-        assert ride["indoor_ftp"] == 250
+        assert ride["ftp_watts"] == 260
+        assert ride["indoor_ftp_watts"] == 250
         swim = next(s for s in sports if s["type"] == "Swim")
-        assert swim["swim_threshold"] == 95.0
+        assert swim["swim_threshold"] == "1:35 /100m"
 
 
 class TestAthleteProfileErrors:

--- a/tests/test_athlete_branches.py
+++ b/tests/test_athlete_branches.py
@@ -57,9 +57,7 @@ class TestAthleteProfileFormBuckets:
             (-10.0, "declining_significantly"),
         ],
     )
-    async def test_ramp_rate_buckets(
-        self, ramp_rate, expected_status, mock_config, respx_mock
-    ):
+    async def test_ramp_rate_buckets(self, ramp_rate, expected_status, mock_config, respx_mock):
         respx_mock.get("/athlete/i123456").mock(
             return_value=Response(
                 200,
@@ -87,7 +85,13 @@ class TestAthleteProfileSportSettings:
                     "name": "Test",
                     "sport_settings": [
                         {"id": 1, "type": "Run", "fthr": 170, "pace_threshold": 240.0},
-                        {"id": 2, "type": "Ride", "ftp": 260, "fthr": 165},
+                        {
+                            "id": 2,
+                            "type": "Ride",
+                            "ftp": 260,
+                            "indoor_ftp": 250,
+                            "fthr": 165,
+                        },
                         {"id": 3, "type": "Swim", "swim_threshold": 95.0},
                     ],
                 },
@@ -102,6 +106,7 @@ class TestAthleteProfileSportSettings:
         assert run["pace_threshold_formatted"] == "4:00 /km"
         ride = next(s for s in sports if s["type"] == "Ride")
         assert ride["ftp"] == 260
+        assert ride["indoor_ftp"] == 250
         swim = next(s for s in sports if s["type"] == "Swim")
         assert swim["swim_threshold"] == 95.0
 

--- a/tests/test_multi_athlete_and_models.py
+++ b/tests/test_multi_athlete_and_models.py
@@ -250,6 +250,69 @@ class TestMultiAthleteEventManagement:
 # ==================== Pydantic Aliases (watts fields) ====================
 
 
+class TestSportSettingsModelMapping:
+    """SportSettings and Athlete parse Intervals.icu API field names."""
+
+    def test_sport_settings_maps_lthr_types_and_threshold_pace(self):
+        from intervals_icu_mcp.models import SportSettings
+
+        settings = SportSettings.model_validate(
+            {
+                "id": 1,
+                "types": ["Ride", "VirtualRide"],
+                "ftp": 242,
+                "indoor_ftp": 232,
+                "lthr": 176,
+            }
+        )
+
+        assert settings.type == "Ride"
+        assert settings.ftp == 242
+        assert settings.indoor_ftp == 232
+        assert settings.fthr == 176
+
+    def test_sport_settings_maps_swim_threshold_from_seconds(self):
+        from intervals_icu_mcp.models import SportSettings
+
+        settings = SportSettings.model_validate(
+            {
+                "id": 3,
+                "types": ["Swim"],
+                "threshold_pace": 90,
+                "pace_units": "SECS_100M",
+                "pace_load_type": "SWIM",
+            }
+        )
+
+        assert settings.type == "Swim"
+        assert settings.swim_threshold == 1.5
+        assert settings.pace_threshold is None
+
+    def test_athlete_maps_sport_settings_camel_case(self):
+        from intervals_icu_mcp.models import Athlete
+
+        athlete = Athlete.model_validate(
+            {
+                "id": "i123456",
+                "name": "Test",
+                "sportSettings": [
+                    {
+                        "id": 1,
+                        "types": ["Ride"],
+                        "ftp": 250,
+                        "indoor_ftp": 235,
+                        "lthr": 165,
+                    }
+                ],
+            }
+        )
+
+        assert len(athlete.sport_settings) == 1
+        assert athlete.sport_settings[0].type == "Ride"
+        assert athlete.sport_settings[0].indoor_ftp == 235
+        assert athlete.sport_settings[0].fthr == 165
+
+
 class TestPydanticAliases:
     """Test that icu_average_watts / icu_weighted_avg_watts map correctly."""
 

--- a/tests/test_multi_athlete_and_models.py
+++ b/tests/test_multi_athlete_and_models.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from httpx import Response
 
 from intervals_icu_mcp.tools.activities import get_recent_activities, search_activities
@@ -287,6 +288,12 @@ class TestSportSettingsModelMapping:
         assert settings.type == "Swim"
         assert settings.swim_threshold == 1.5
         assert settings.pace_threshold is None
+
+    def test_build_sport_settings_api_payload_rejects_both_pace_params(self):
+        from intervals_icu_mcp.sport_settings_format import build_sport_settings_api_payload
+
+        with pytest.raises(ValueError, match="pace_threshold and swim_threshold"):
+            build_sport_settings_api_payload(pace_threshold=4.5, swim_threshold=1.5)
 
     def test_athlete_maps_sport_settings_camel_case(self):
         from intervals_icu_mcp.models import Athlete

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -14,6 +14,29 @@ from intervals_icu_mcp.tools.sport_settings import (
     update_sport_settings,
 )
 
+RIDE_SETTINGS = {
+    "id": 1,
+    "types": ["Ride", "VirtualRide"],
+    "ftp": 250,
+    "indoor_ftp": 235,
+    "lthr": 165,
+}
+RUN_SETTINGS = {
+    "id": 2,
+    "types": ["Run"],
+    "lthr": 170,
+    "threshold_pace": 4.5,
+    "pace_units": "MINS_KM",
+    "pace_load_type": "RUN",
+}
+SWIM_SETTINGS = {
+    "id": 3,
+    "types": ["Swim"],
+    "threshold_pace": 90,
+    "pace_units": "SECS_100M",
+    "pace_load_type": "SWIM",
+}
+
 
 @pytest.fixture
 def patch_config(monkeypatch, mock_config):
@@ -28,29 +51,7 @@ class TestSportSettingsTools:
     async def test_get_sport_settings_success(self, patch_config, respx_mock):
         """Returns a list of sport settings with formatted pace/swim thresholds."""
         respx_mock.get("/athlete/i123456/sport-settings").mock(
-            return_value=Response(
-                200,
-                json=[
-                    {
-                        "id": 1,
-                        "type": "Ride",
-                        "ftp": 250,
-                        "indoor_ftp": 235,
-                        "fthr": 165,
-                    },
-                    {
-                        "id": 2,
-                        "type": "Run",
-                        "fthr": 170,
-                        "pace_threshold": 4.5,
-                    },
-                    {
-                        "id": 3,
-                        "type": "Swim",
-                        "swim_threshold": 1.5,
-                    },
-                ],
-            )
+            return_value=Response(200, json=[RIDE_SETTINGS, RUN_SETTINGS, SWIM_SETTINGS])
         )
 
         result = await get_sport_settings()
@@ -59,6 +60,7 @@ class TestSportSettingsTools:
         assert "data" in response
         settings = response["data"]["sport_settings"]
         assert len(settings) == 3
+        assert settings[0]["type"] == "Ride"
         assert settings[0]["ftp_watts"] == 250
         assert settings[0]["indoor_ftp_watts"] == 235
         assert settings[0]["fthr_bpm"] == 165
@@ -100,7 +102,13 @@ class TestSportSettingsTools:
         route = respx_mock.put("/athlete/i123456/sport-settings/1").mock(
             return_value=Response(
                 200,
-                json={"id": 1, "type": "Ride", "ftp": 275, "indoor_ftp": 265, "fthr": 165},
+                json={
+                    "id": 1,
+                    "types": ["Ride"],
+                    "ftp": 275,
+                    "indoor_ftp": 265,
+                    "lthr": 165,
+                },
             )
         )
 
@@ -110,8 +118,38 @@ class TestSportSettingsTools:
         assert "data" in response
         assert response["data"]["ftp_watts"] == 275
         assert response["data"]["indoor_ftp_watts"] == 265
-        assert json.loads(route.calls.last.request.content) == {"ftp": 275, "indoor_ftp": 265}
+        assert json.loads(route.calls.last.request.content) == {
+            "ftp": 275,
+            "indoor_ftp": 265,
+        }
         assert response["metadata"]["message"] == "Sport settings updated successfully"
+
+    async def test_update_sport_settings_sends_lthr(self, patch_config, respx_mock):
+        """FTHR updates are sent to the API as lthr."""
+        route = respx_mock.put("/athlete/i123456/sport-settings/2").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": 2,
+                    "types": ["Run"],
+                    "lthr": 172,
+                    "threshold_pace": 4.5,
+                    "pace_units": "MINS_KM",
+                    "pace_load_type": "RUN",
+                },
+            )
+        )
+
+        result = await update_sport_settings(sport_id=2, fthr=172, pace_threshold=4.5)
+
+        response = json.loads(result)
+        assert response["data"]["fthr_bpm"] == 172
+        assert json.loads(route.calls.last.request.content) == {
+            "lthr": 172,
+            "threshold_pace": 4.5,
+            "pace_units": "MINS_KM",
+            "pace_load_type": "RUN",
+        }
 
     async def test_update_sport_settings_requires_a_field(self, patch_config):
         """Validation: update with no thresholds returns a validation error."""
@@ -149,14 +187,16 @@ class TestSportSettingsTools:
 
     async def test_create_sport_settings_success(self, patch_config, respx_mock):
         """Successfully creating a new Run settings object."""
-        respx_mock.post("/athlete/i123456/sport-settings").mock(
+        route = respx_mock.post("/athlete/i123456/sport-settings").mock(
             return_value=Response(
                 200,
                 json={
                     "id": 7,
-                    "type": "Run",
-                    "fthr": 170,
-                    "pace_threshold": 4.5,
+                    "types": ["Run"],
+                    "lthr": 170,
+                    "threshold_pace": 4.5,
+                    "pace_units": "MINS_KM",
+                    "pace_load_type": "RUN",
                 },
             )
         )
@@ -171,6 +211,13 @@ class TestSportSettingsTools:
         assert response["data"]["id"] == 7
         assert response["data"]["type"] == "Run"
         assert response["data"]["pace_threshold"] == "4:30 /km"
+        assert json.loads(route.calls.last.request.content) == {
+            "types": ["Run"],
+            "lthr": 170,
+            "threshold_pace": 4.5,
+            "pace_units": "MINS_KM",
+            "pace_load_type": "RUN",
+        }
         assert response["metadata"]["message"] == "Sport settings created successfully"
 
     async def test_create_sport_settings_with_indoor_ftp(self, patch_config, respx_mock):
@@ -178,7 +225,7 @@ class TestSportSettingsTools:
         route = respx_mock.post("/athlete/i123456/sport-settings").mock(
             return_value=Response(
                 200,
-                json={"id": 8, "type": "Ride", "ftp": 275, "indoor_ftp": 265},
+                json={"id": 8, "types": ["Ride"], "ftp": 275, "indoor_ftp": 265},
             )
         )
 
@@ -187,7 +234,7 @@ class TestSportSettingsTools:
         response = json.loads(result)
         assert response["data"]["indoor_ftp_watts"] == 265
         assert json.loads(route.calls.last.request.content) == {
-            "type": "Ride",
+            "types": ["Ride"],
             "ftp": 275,
             "indoor_ftp": 265,
         }

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -122,6 +122,7 @@ class TestSportSettingsTools:
             "ftp": 275,
             "indoor_ftp": 265,
         }
+        assert route.calls.last.request.url.params["recalcHrZones"] == "true"
         assert response["metadata"]["message"] == "Sport settings updated successfully"
 
     async def test_update_sport_settings_sends_lthr(self, patch_config, respx_mock):
@@ -171,13 +172,23 @@ class TestSportSettingsTools:
         assert "error" in response
         assert "Resource not found" in response["error"]["message"]
 
+    async def test_update_sport_settings_recalc_hr_zones_false(self, patch_config, respx_mock):
+        """recalc_hr_zones=false is forwarded as recalcHrZones query param."""
+        route = respx_mock.put("/athlete/i123456/sport-settings/2").mock(
+            return_value=Response(200, json={"id": 2, "types": ["Run"], "lthr": 170})
+        )
+
+        await update_sport_settings(sport_id=2, fthr=170, recalc_hr_zones=False)
+
+        assert route.calls.last.request.url.params["recalcHrZones"] == "false"
+
     async def test_apply_sport_settings_success(self, patch_config, respx_mock):
-        """Apply settings returns the API payload verbatim with metadata."""
-        respx_mock.post("/athlete/i123456/sport-settings/1/apply").mock(
+        """Apply settings uses PUT and returns the API payload with metadata."""
+        respx_mock.put("/athlete/i123456/sport-settings/1/apply").mock(
             return_value=Response(200, json={"applied": 42})
         )
 
-        result = await apply_sport_settings(sport_id=1, oldest_date="2026-01-01")
+        result = await apply_sport_settings(sport_id=1)
 
         response = json.loads(result)
         assert response["data"]["applied"] == 42

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -160,6 +160,21 @@ class TestSportSettingsTools:
         assert "error" in response
         assert "No fields provided" in response["error"]["message"]
 
+    async def test_update_sport_settings_rejects_both_pace_params(self, patch_config, respx_mock):
+        """Validation: pace_threshold and swim_threshold cannot be set in the same call."""
+        route = respx_mock.put("/athlete/i123456/sport-settings/2").mock(
+            return_value=Response(200, json={"id": 2, "types": ["Run"]})
+        )
+
+        result = await update_sport_settings(sport_id=2, pace_threshold=4.5, swim_threshold=1.5)
+
+        response = json.loads(result)
+        assert "error" in response
+        assert response["error"]["type"] == "validation_error"
+        assert "pace_threshold" in response["error"]["message"]
+        assert "swim_threshold" in response["error"]["message"]
+        assert not route.called
+
     async def test_update_sport_settings_api_error(self, patch_config, respx_mock):
         """404 from the API surfaces as an error response."""
         respx_mock.put("/athlete/i123456/sport-settings/999").mock(
@@ -230,6 +245,25 @@ class TestSportSettingsTools:
             "pace_load_type": "RUN",
         }
         assert response["metadata"]["message"] == "Sport settings created successfully"
+
+    async def test_create_sport_settings_rejects_both_pace_params(self, patch_config, respx_mock):
+        """Validation: pace_threshold and swim_threshold cannot be set in the same call."""
+        route = respx_mock.post("/athlete/i123456/sport-settings").mock(
+            return_value=Response(200, json={"id": 7, "types": ["Run"]})
+        )
+
+        result = await create_sport_settings(
+            sport_type="Run",
+            pace_threshold=4.5,
+            swim_threshold=1.5,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+        assert response["error"]["type"] == "validation_error"
+        assert "pace_threshold" in response["error"]["message"]
+        assert "swim_threshold" in response["error"]["message"]
+        assert not route.called
 
     async def test_create_sport_settings_with_indoor_ftp(self, patch_config, respx_mock):
         """Indoor FTP is sent to the API and returned in the created settings."""

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -31,7 +31,13 @@ class TestSportSettingsTools:
             return_value=Response(
                 200,
                 json=[
-                    {"id": 1, "type": "Ride", "ftp": 250, "fthr": 165},
+                    {
+                        "id": 1,
+                        "type": "Ride",
+                        "ftp": 250,
+                        "indoor_ftp": 235,
+                        "fthr": 165,
+                    },
                     {
                         "id": 2,
                         "type": "Run",
@@ -54,6 +60,7 @@ class TestSportSettingsTools:
         settings = response["data"]["sport_settings"]
         assert len(settings) == 3
         assert settings[0]["ftp_watts"] == 250
+        assert settings[0]["indoor_ftp_watts"] == 235
         assert settings[0]["fthr_bpm"] == 165
         assert settings[1]["pace_threshold"] == "4:30 /km"
         assert settings[2]["swim_threshold"] == "1:30 /100m"
@@ -89,19 +96,21 @@ class TestSportSettingsTools:
         assert "credentials not configured" in result
 
     async def test_update_sport_settings_success(self, patch_config, respx_mock):
-        """Successful FTP update returns formatted settings."""
-        respx_mock.put("/athlete/i123456/sport-settings/1").mock(
+        """Successful outdoor and indoor FTP update returns formatted settings."""
+        route = respx_mock.put("/athlete/i123456/sport-settings/1").mock(
             return_value=Response(
                 200,
-                json={"id": 1, "type": "Ride", "ftp": 275, "fthr": 165},
+                json={"id": 1, "type": "Ride", "ftp": 275, "indoor_ftp": 265, "fthr": 165},
             )
         )
 
-        result = await update_sport_settings(sport_id=1, ftp=275)
+        result = await update_sport_settings(sport_id=1, ftp=275, indoor_ftp=265)
 
         response = json.loads(result)
         assert "data" in response
         assert response["data"]["ftp_watts"] == 275
+        assert response["data"]["indoor_ftp_watts"] == 265
+        assert json.loads(route.calls.last.request.content) == {"ftp": 275, "indoor_ftp": 265}
         assert response["metadata"]["message"] == "Sport settings updated successfully"
 
     async def test_update_sport_settings_requires_a_field(self, patch_config):
@@ -163,6 +172,25 @@ class TestSportSettingsTools:
         assert response["data"]["type"] == "Run"
         assert response["data"]["pace_threshold"] == "4:30 /km"
         assert response["metadata"]["message"] == "Sport settings created successfully"
+
+    async def test_create_sport_settings_with_indoor_ftp(self, patch_config, respx_mock):
+        """Indoor FTP is sent to the API and returned in the created settings."""
+        route = respx_mock.post("/athlete/i123456/sport-settings").mock(
+            return_value=Response(
+                200,
+                json={"id": 8, "type": "Ride", "ftp": 275, "indoor_ftp": 265},
+            )
+        )
+
+        result = await create_sport_settings(sport_type="Ride", ftp=275, indoor_ftp=265)
+
+        response = json.loads(result)
+        assert response["data"]["indoor_ftp_watts"] == 265
+        assert json.loads(route.calls.last.request.content) == {
+            "type": "Ride",
+            "ftp": 275,
+            "indoor_ftp": 265,
+        }
 
     async def test_delete_sport_settings_success(self, patch_config, respx_mock):
         """Delete returns a confirmation payload."""

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -45,6 +45,13 @@ class TestInMemoryTransport:
             assert "icu_get_custom_items" in names  # Custom items
             assert "icu_update_sport_settings" in names
 
+    async def test_sport_settings_tools_expose_indoor_ftp(self):
+        """Create and update schemas accept the separate indoor power threshold."""
+        async with Client(mcp) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+            for name in {"icu_create_sport_settings", "icu_update_sport_settings"}:
+                assert "indoor_ftp" in tools[name].inputSchema["properties"]
+
     async def test_tools_use_icu_prefix(self):
         """Every tool follows the naming convention documented in the README."""
         async with Client(mcp) as client:

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -51,6 +51,8 @@ class TestInMemoryTransport:
             tools = {tool.name: tool for tool in await client.list_tools()}
             for name in {"icu_create_sport_settings", "icu_update_sport_settings"}:
                 assert "indoor_ftp" in tools[name].inputSchema["properties"]
+            assert "recalc_hr_zones" in tools["icu_update_sport_settings"].inputSchema["properties"]
+            assert "oldest_date" not in tools["icu_apply_sport_settings"].inputSchema["properties"]
 
     async def test_tools_use_icu_prefix(self):
         """Every tool follows the naming convention documented in the README."""


### PR DESCRIPTION
## Summary

Fixes sport settings read/write gaps against the live Intervals.icu API: exposes `indoor_ftp`, maps OpenAPI field names (`sportSettings`, `lthr`, `threshold_pace`, `types`), unifies LLM-facing threshold output, and aligns update/apply client calls with the documented contract.

## Changes

- Add `indoor_ftp` to `SportSettings` and surface it in get/update/create, athlete profile, and the profile resource
- Map API → model: `sportSettings`, `lthr`, `threshold_pace`, `types[]`, swim pace via `SECS_100M`
- Translate MCP writes to API fields (`types`, `lthr`, `threshold_pace` + pace metadata)
- Shared `sport_settings_format.py` for consistent output (`ftp_watts`, `indoor_ftp_watts`, `fthr_bpm`, formatted pace/swim)
- Send required `recalcHrZones` query param on update; add `recalc_hr_zones` tool parameter (default `true`)
- Fix apply: `POST` → `PUT` (live API returns 405 on POST); remove non-functional `oldest_date` param
- Replace legacy test mocks with OpenAPI-shaped payloads; add model mapping tests
- Docs: remove misleading "zone configuration" claim; clarify apply/update descriptions

## Checklist

- [x] `make can-release` passes locally (pytest 286/286, ruff, pyright, 84% coverage)
- [x] New tools have a corresponding respx-mocked test file in `tests/` (N/A — extended existing sport settings tests)
- [x] Public-facing behavior changes are reflected in the README or `docs/`
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

- [x] Unit tests: `tests/test_sport_settings_tools.py`, `tests/test_athlete_branches.py`, `tests/test_multi_athlete_and_models.py`, `tests/test_transport_integration.py`
- [x] Live API verification against Intervals.icu account:
  - GET `/sport-settings` parses `ftp`, `indoor_ftp`, `lthr`
  - GET `/athlete` parses embedded `sportSettings` (was 0 before fix)
  - PUT apply succeeds via PUT; POST apply returns 405
  - PUT update with `recalcHrZones=false` succeeds

**SemVer note:** Removing `oldest_date` from `icu_apply_sport_settings` is a parameter removal, but the param never worked against the live API (POST returned 405). Treat as a bug fix, not a breaking release.
