### PR TITLE
feat(tools): add icu_get_fitness_chart for PMC time-series

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for Intervals.icu — provides up to 60 tools, 4 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 57 tools; `full` registers all 60, `none` registers 54.
+MCP (Model Context Protocol) server for Intervals.icu — provides up to 61 tools, 4 resources, and 9 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs. The default `INTERVALS_ICU_DELETE_MODE=safe` registers 58 tools; `full` registers all 61, `none` registers 55.
 
 - **Language**: Python 3.11+
 - **Framework**: FastMCP

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-60 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 4 MCP Resources (athlete profile, workout syntax, event categories, custom item schemas) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
+61 tools spanning activities, activity analysis, activity messages, athlete profile, wellness, events/calendar, performance curves, workout library, gear, sport settings, and custom items — plus 4 MCP Resources (athlete profile, workout syntax, event categories, custom item schemas) and 7 MCP Prompts (training analysis, recovery check, weekly planning, and more). See [Available Tools](#available-tools) for the per-category breakdown.
 
 ## Quick Start
 
@@ -213,14 +213,14 @@ For the full catalogue of example prompts by category, see [docs/examples.md](ht
 
 ## Available Tools
 
-60 tools, 4 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
+61 tools, 4 resources, and 7 prompt templates. One-line summary below — full reference in [docs/tools.md](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md).
 
 | Category | Tools | Summary |
 |---|---|---|
 | [Activities](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activities-12-tools) | 12 | Query, search, update, delete, download activities |
 | [Activity Analysis](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activity-analysis-8-tools) | 8 | Streams, intervals, best efforts, histograms |
 | [Activity Messages](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#activity-messages-2-tools) | 2 | Read and post notes/comments/coach feedback on activities |
-| [Athlete](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#athlete-2-tools) | 2 | Profile and CTL/ATL/TSB fitness analysis |
+| [Athlete](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#athlete-3-tools) | 3 | Profile, CTL/ATL/TSB analysis, and fitness chart time-series |
 | [Wellness](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#wellness-3-tools) | 3 | HRV, sleep, recovery metrics |
 | [Events / Calendar](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#events--calendar-11-tools) | 11 | Planned workouts, races, notes, ATP periodization (bulk ops supported) |
 | [Performance / Curves](https://github.com/hhopke/intervals-icu-mcp/blob/main/docs/tools.md#performance--curves-3-tools) | 3 | Power, HR, and pace curves with zones |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool, Resource, and Prompt Reference
 
-Complete inventory of everything the Intervals.icu MCP server exposes: up to 60 tools across 11 categories, 4 MCP Resources, and 7 MCP Prompts.
+Complete inventory of everything the Intervals.icu MCP server exposes: up to 61 tools across 11 categories, 4 MCP Resources, and 7 MCP Prompts.
 
 ## Delete Safety Mode
 
@@ -88,12 +88,13 @@ The threaded notes/comments shown under an activity — the user's own training 
 | `icu_get_activity_messages`    | Read notes/comments/coach feedback on a specific activity  |
 | `icu_add_activity_message`     | Post a note or comment on a specific activity              |
 
-### Athlete (2 tools)
+### Athlete (3 tools)
 
 | Tool                  | Description                                                     |
 | --------------------- | --------------------------------------------------------------- |
 | `icu_get_athlete_profile` | Get athlete profile, fitness metrics, and outdoor/indoor FTP   |
 | `icu_get_fitness_summary` | Get detailed CTL/ATL/TSB analysis with training recommendations |
+| `icu_get_fitness_chart` | Get PMC time-series (CTL/ATL/TSB) over a date window, including future projections from planned workouts |
 
 ### Wellness (3 tools)
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -423,6 +423,7 @@ class ICUClient:
         athlete_id: str | None = None,
         oldest: str | None = None,
         newest: str | None = None,
+        fields: list[str] | None = None,
     ) -> list[Wellness]:
         """Get wellness records for a date range.
 
@@ -430,17 +431,20 @@ class ICUClient:
             athlete_id: Athlete ID (uses config default if not provided)
             oldest: Oldest date to fetch (ISO-8601 format)
             newest: Newest date to fetch (ISO-8601 format)
+            fields: Optional list of field names to include in each record
 
         Returns:
             List of Wellness records
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, str] = {}
 
         if oldest:
             params["oldest"] = oldest
         if newest:
             params["newest"] = newest
+        if fields:
+            params["fields"] = ",".join(fields)
 
         response = await self._request("GET", f"/athlete/{athlete_id}/wellness", params=params)
         adapter = TypeAdapter(list[Wellness])

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -51,7 +51,7 @@ from .tools.activity_analysis import (
     search_intervals,
 )
 from .tools.activity_messages import add_activity_message, get_activity_messages
-from .tools.athlete import get_athlete_profile, get_fitness_summary
+from .tools.athlete import get_athlete_profile, get_fitness_chart, get_fitness_summary
 from .tools.curves import get_hr_curves, get_pace_curves
 from .tools.custom_items import (
     create_custom_item,
@@ -303,6 +303,15 @@ mcp.tool(
         "openWorldHint": True,
     },
 )(get_fitness_summary)
+mcp.tool(
+    name="icu_get_fitness_chart",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)(get_fitness_chart)
 
 # Register wellness tools
 mcp.tool(
@@ -800,12 +809,13 @@ async def analyze_recent_training(days: str = "30") -> str:
 Focus on:
 1. Training volume (distance, time, elevation, training load)
 2. Training distribution by activity type
-3. Fitness trends (CTL/ATL/TSB)
+3. Fitness trends (CTL/ATL/TSB) — use icu_get_fitness_chart for the time-series
 4. Recovery metrics (HRV, sleep, wellness)
 5. Key insights and recommendations
 
-Use get_recent_activities with days_back={days}, get_fitness_summary for CTL/ATL/TSB analysis,
-and get_wellness_data to assess recovery. Present findings in a clear, actionable format."""
+Use get_recent_activities with days_back={days}, icu_get_fitness_chart for CTL/ATL/TSB trends,
+icu_get_fitness_summary for today's form, and get_wellness_data to assess recovery.
+Present findings in a clear, actionable format."""
 
 
 @mcp.prompt()

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -1,14 +1,65 @@
 """Athlete profile and fitness tools for Intervals.icu MCP server."""
 
-from datetime import date
-from typing import Any
+from datetime import date, timedelta
+from typing import Annotated, Any
 
 from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
+from ..models import Wellness
 from ..response_builder import ResponseBuilder
 from ..sport_settings_format import format_sport_settings_entry
+
+MAX_FITNESS_CHART_DAYS = 365
+_FITNESS_CHART_FIELDS = ["id", "ctl", "atl", "rampRate", "ctlLoad", "atlLoad"]
+
+
+def _fitness_metrics_point(record: Wellness, today: date) -> dict[str, Any] | None:
+    """Shape one wellness record into a lean PMC data point, or None if no fitness data."""
+    if record.ctl is None and record.atl is None:
+        return None
+
+    record_date = date.fromisoformat(record.id)
+    point: dict[str, Any] = {
+        "date": record.id,
+        "is_projected": record_date > today,
+    }
+    if record.ctl is not None:
+        point["ctl"] = round(record.ctl, 1)
+    if record.atl is not None:
+        point["atl"] = round(record.atl, 1)
+
+    tsb = record.tsb
+    if tsb is None and record.ctl is not None and record.atl is not None:
+        tsb = record.ctl - record.atl
+    if tsb is not None:
+        point["tsb"] = round(tsb, 1)
+    if record.ramp_rate is not None:
+        point["ramp_rate"] = round(record.ramp_rate, 1)
+    if record.ctl_load is not None:
+        point["ctl_load"] = round(record.ctl_load, 1)
+    if record.atl_load is not None:
+        point["atl_load"] = round(record.atl_load, 1)
+
+    return point
+
+
+def _fitness_chart_summary(series: list[dict[str, Any]], today: date) -> dict[str, Any]:
+    """Build start/today/end summary from an ascending fitness chart series."""
+    summary: dict[str, Any] = {}
+    today_str = today.isoformat()
+
+    if series:
+        summary["start"] = {k: v for k, v in series[0].items() if k != "date"}
+        summary["end"] = {k: v for k, v in series[-1].items() if k != "date"}
+
+    for point in series:
+        if point["date"] == today_str:
+            summary["today"] = {k: v for k, v in point.items() if k != "date"}
+            break
+
+    return summary
 
 
 async def get_athlete_profile(
@@ -252,6 +303,110 @@ async def get_fitness_summary(
                 data,
                 analysis=analysis,
                 query_type="fitness_summary",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(
+            e.message,
+            error_type="api_error",
+        )
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}",
+            error_type="internal_error",
+        )
+
+
+async def get_fitness_chart(
+    days_back: Annotated[int, "Number of days before today to include (inclusive)"],
+    days_ahead: Annotated[
+        int, "Number of days after today to include (inclusive); use 0 for history only"
+    ],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Fetch the Performance Management Chart time-series — daily CTL, ATL, and TSB.
+
+    Returns past history plus future projections from planned calendar workouts.
+    Use for: "show my fitness chart", "CTL trend last 90 days", "projected form
+    at end of my block", "what will my TSB be in 3 weeks".
+    NOT for: today's training recommendations (icu_get_fitness_summary), HRV/sleep/
+    recovery trends (icu_get_wellness_data), or one day's full wellness record
+    (icu_get_wellness_for_date).
+    """
+    assert ctx is not None
+    config: ICUConfig = await ctx.get_state("config")
+
+    if days_back < 0 or days_ahead < 0:
+        return ResponseBuilder.build_error_response(
+            "days_back and days_ahead must be zero or positive.",
+            error_type="validation_error",
+        )
+
+    if days_back + days_ahead > MAX_FITNESS_CHART_DAYS:
+        return ResponseBuilder.build_error_response(
+            f"Total date window cannot exceed {MAX_FITNESS_CHART_DAYS} days "
+            f"(days_back + days_ahead = {days_back + days_ahead}). "
+            "Use a smaller range.",
+            error_type="validation_error",
+        )
+
+    today = date.today()
+    oldest = (today - timedelta(days=days_back)).isoformat()
+    newest = (today + timedelta(days=days_ahead)).isoformat()
+
+    try:
+        async with ICUClient(config) as client:
+            records = await client.get_wellness(
+                athlete_id=athlete_id,
+                oldest=oldest,
+                newest=newest,
+                fields=_FITNESS_CHART_FIELDS,
+            )
+
+            series: list[dict[str, Any]] = []
+            for record in records:
+                point = _fitness_metrics_point(record, today)
+                if point is not None:
+                    series.append(point)
+
+            series.sort(key=lambda p: p["date"])
+
+            metadata: dict[str, Any] = {
+                "projections_note": (
+                    "Future values include planned calendar workouts when the athlete's "
+                    "Intervals.icu setting 'Include planned workouts in fitness' is enabled."
+                ),
+                "sparse_series_note": (
+                    "Days without a wellness record are omitted (not zero-filled)."
+                ),
+            }
+
+            if not series:
+                return ResponseBuilder.build_response(
+                    data={
+                        "date_range": {"oldest": oldest, "newest": newest},
+                        "count": 0,
+                        "series": [],
+                    },
+                    metadata={
+                        **metadata,
+                        "message": "No fitness chart data found for the specified date range.",
+                    },
+                    query_type="fitness_chart",
+                )
+
+            data: dict[str, Any] = {
+                "date_range": {"oldest": oldest, "newest": newest},
+                "count": len(series),
+                "series": series,
+                "summary": _fitness_chart_summary(series, today),
+            }
+
+            return ResponseBuilder.build_response(
+                data=data,
+                metadata=metadata,
+                query_type="fitness_chart",
             )
 
     except ICUAPIError as e:

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -192,8 +192,9 @@ async def get_wellness_data(
     """Fetch wellness records over a RANGE of recent days (default last 7).
 
     Use for trends, weekly summaries, "how has my sleep been this week?",
-    recovery curves. For a single specific date use icu_get_wellness_for_date
-    instead — this tool always returns a multi-day list.
+    recovery curves. For PMC/fitness chart CTL/ATL/TSB series use
+    icu_get_fitness_chart. For a single specific date use
+    icu_get_wellness_for_date instead — this tool always returns a multi-day list.
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
@@ -353,8 +354,12 @@ async def update_wellness(
     respiration: Annotated[float | None, "Respiration rate in breaths per minute"] = None,
     blood_glucose: Annotated[float | None, "Blood glucose in mmol/L"] = None,
     lactate: Annotated[float | None, "Blood lactate in mmol/L — lab result"] = None,
-    menstrual_phase: Annotated[str | None, "Menstrual phase (e.g. FOLLICULAR, OVULATING, LUTEAL, MENSTRUAL)"] = None,
-    locked: Annotated[bool | None, "Lock record to prevent device sync from overwriting manual entries"] = None,
+    menstrual_phase: Annotated[
+        str | None, "Menstrual phase (e.g. FOLLICULAR, OVULATING, LUTEAL, MENSTRUAL)"
+    ] = None,
+    locked: Annotated[
+        bool | None, "Lock record to prevent device sync from overwriting manual entries"
+    ] = None,
     calories_consumed: Annotated[int | None, "Calories consumed (kcal)"] = None,
     carbohydrates: Annotated[float | None, "Carbohydrates consumed (grams)"] = None,
     protein: Annotated[float | None, "Protein consumed (grams)"] = None,

--- a/tests/test_athlete_tools.py
+++ b/tests/test_athlete_tools.py
@@ -1,11 +1,16 @@
 """Tests for athlete tools."""
 
+import json
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import Response
 
-from intervals_icu_mcp.tools.athlete import get_athlete_profile, get_fitness_summary
+from intervals_icu_mcp.tools.athlete import (
+    get_athlete_profile,
+    get_fitness_chart,
+    get_fitness_summary,
+)
 
 
 class TestGetAthleteProfile:
@@ -106,3 +111,120 @@ class TestGetFitnessSummary:
         assert "analysis" in response
         assert "ramp_rate_status" in response["analysis"]
         assert response["analysis"]["ramp_rate_status"] == "high_risk"
+
+
+class TestGetFitnessChart:
+    """Tests for get_fitness_chart tool."""
+
+    @patch("intervals_icu_mcp.tools.athlete.date")
+    async def test_get_fitness_chart_success(self, mock_date, mock_config, respx_mock):
+        """Past and future records are tagged, sorted ascending, and summarized."""
+        mock_date.today.return_value = date(2026, 3, 17)
+        mock_date.fromisoformat.side_effect = date.fromisoformat
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": "2026-03-20",
+                        "ctl": 55.0,
+                        "atl": 60.0,
+                        "ctlLoad": 80,
+                        "atlLoad": 90,
+                    },
+                    {
+                        "id": "2026-03-15",
+                        "ctl": 48.0,
+                        "atl": 42.0,
+                        "rampRate": 2.5,
+                    },
+                    {
+                        "id": "2026-03-17",
+                        "ctl": 50.0,
+                        "atl": 35.0,
+                        "tsb": 15.0,
+                    },
+                ],
+            )
+        )
+
+        result = await get_fitness_chart(days_back=7, days_ahead=3, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["count"] == 3
+        series = response["data"]["series"]
+        assert [point["date"] for point in series] == [
+            "2026-03-15",
+            "2026-03-17",
+            "2026-03-20",
+        ]
+        assert series[0]["ctl"] == 48.0
+        assert series[0]["tsb"] == 6.0  # computed from ctl - atl
+        assert series[1]["is_projected"] is False
+        assert series[2]["is_projected"] is True
+        assert series[2]["tsb"] == -5.0
+        assert response["data"]["summary"]["today"]["ctl"] == 50.0
+        assert response["data"]["summary"]["end"]["ctl"] == 55.0
+        assert "projections_note" in response["metadata"]
+
+    @patch("intervals_icu_mcp.tools.athlete.date")
+    async def test_get_fitness_chart_fields_param(self, mock_date, mock_config, respx_mock):
+        """Fitness-only fields are requested from the wellness API."""
+        mock_date.today.return_value = date(2026, 3, 17)
+        mock_date.fromisoformat.side_effect = date.fromisoformat
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(
+                200,
+                json=[{"id": "2026-03-17", "ctl": 50.0, "atl": 35.0}],
+            )
+        )
+
+        await get_fitness_chart(days_back=7, days_ahead=0, ctx=mock_ctx)
+
+        assert route.calls.last.request.url.params["fields"] == (
+            "id,ctl,atl,rampRate,ctlLoad,atlLoad"
+        )
+
+    async def test_get_fitness_chart_negative_days(self, mock_config):
+        """Negative windows are rejected before any HTTP call."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await get_fitness_chart(days_back=-1, days_ahead=7, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+
+    async def test_get_fitness_chart_exceeds_cap(self, mock_config):
+        """Total window over 365 days is rejected."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        result = await get_fitness_chart(days_back=200, days_ahead=200, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["error"]["type"] == "validation_error"
+        assert "365" in response["error"]["message"]
+
+    @patch("intervals_icu_mcp.tools.athlete.date")
+    async def test_get_fitness_chart_empty(self, mock_date, mock_config, respx_mock):
+        """Empty API response returns count 0 without error."""
+        mock_date.today.return_value = date(2026, 3, 17)
+        mock_date.fromisoformat.side_effect = date.fromisoformat
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness").mock(return_value=Response(200, json=[]))
+
+        result = await get_fitness_chart(days_back=7, days_ahead=0, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["count"] == 0
+        assert response["data"]["series"] == []
+        assert "message" in response["metadata"]

--- a/tests/test_transport_integration.py
+++ b/tests/test_transport_integration.py
@@ -31,14 +31,15 @@ class TestInMemoryTransport:
             assert client.is_connected()
 
     async def test_all_default_mode_tools_registered(self):
-        """Default delete_mode=safe registers 57 tools (3 destructive tools gated)."""
+        """Default delete_mode=safe registers 58 tools (3 destructive tools gated)."""
         async with Client(mcp) as client:
             tools = await client.list_tools()
-            assert len(tools) == 57
+            assert len(tools) == 58
             names = {t.name for t in tools}
             # Spot-check tools from different modules / tiers
             assert "icu_get_recent_activities" in names
             assert "icu_get_athlete_profile" in names
+            assert "icu_get_fitness_chart" in names
             assert "icu_bulk_create_events" in names  # Tier 2 coverage addition
             assert "icu_duplicate_events" in names
             assert "icu_get_activity_messages" in names  # Activity messages
@@ -201,5 +202,5 @@ class TestHTTPTransport:
                 tools_body = (await tools_resp.aread()).decode()
                 tools_payload = self._parse_sse_response(tools_body)
                 tool_names = {t["name"] for t in tools_payload["result"]["tools"]}
-                assert len(tool_names) == 57  # safe mode default
+                assert len(tool_names) == 58  # safe mode default
                 assert "icu_get_recent_activities" in tool_names


### PR DESCRIPTION
## Summary

Adds `icu_get_fitness_chart`, a read-only MCP tool that returns a lean CTL/ATL/TSB time-series (PMC) over a configurable date window, including future projections from planned calendar workouts via the Intervals.icu wellness API.

## Changes

- New `get_fitness_chart` tool in `athlete.py` with required `days_back` / `days_ahead`, 365-day cap, `is_projected` tagging, and summary block
- Optional `fields` param on `ICUClient.get_wellness()` to fetch fitness columns only
- Register tool in `server.py`; update docs, README athlete count, and wellness docstring cross-ref
- Five respx-mocked tests; transport integration tool count 58 (safe mode)

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/`
- [x] Public-facing behavior changes are reflected in the README or `docs/`
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

- [x] `uv run pytest` — 294 passed, 85% coverage
- [x] `uv run ruff check src tests` and `uv run pyright src` — clean
- [x] Live API smoke (`days_back=14, days_ahead=0` and `days_ahead=14`):
  - History: 15 points, `2026-06-29` → `2026-07-13`, all `is_projected=false`
  - History+future: 29 points, last point `2026-07-27` with `is_projected=true`, CTL 54.4
