### PR TITLE
fix(sport-settings): swim threshold is stored as m/s speed, not a pace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ that preserve the information (key renames, restructuring, added fields) ship in
 clients. (Releases up to and including 4.0.0 treated any response-shape change as
 breaking; this narrower contract applies from the next release onward.)
 
+## [Unreleased]
+
+### Fixed
+- `icu_update_sport_settings` / `icu_create_sport_settings` could not set a swim CSS/threshold pace: the write path multiplied the pace by 60 and sent seconds (e.g. `240` for 4:00/100m), which the API rejects with HTTP 422 "Invalid threshold pace". Intervals.icu stores the swim threshold as **speed in m/s** (unlike run, which is min/km) — confirmed against the live API and UI, where a stored `4.0` renders as `0:25/100m` (= 4 m/s). The swim path now converts min/100m ↔ m/s on both write and read (`100 / (min × 60)`). Verified live end-to-end: setting 4:00/100m stores `0.4167` and renders as `4:00/100m` in Intervals.icu (#88).
+
 ## [4.2.0] — 2026-07-10
 
 ### Added

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -31,9 +31,6 @@ TrainingAvailability = Literal["NORMAL", "LIMITED", "UNAVAILABLE"]
 # ==================== Athlete Models ====================
 
 _SWIM_SPORT_TYPES = frozenset({"Swim", "OpenWaterSwim"})
-_SWIM_PACE_UNITS_SECONDS = frozenset(
-    {"SECS_100M", "SECS_100Y", "SECS_500M", "SECS_400M", "SECS_250M"}
-)
 
 
 class SportSettings(BaseModel):
@@ -68,16 +65,18 @@ class SportSettings(BaseModel):
         threshold_pace = raw.get("threshold_pace")
         if threshold_pace is not None:
             pace_load_type = raw.get("pace_load_type")
-            pace_units = raw.get("pace_units") or ""
             sport_types = cast(list[Any], types) if isinstance(types, list) else []
             is_swim = pace_load_type == "SWIM" or any(
                 isinstance(t, str) and t in _SWIM_SPORT_TYPES for t in sport_types
             )
+            # The API stores RUN pace as min/km (5:45/km -> 5.75) but SWIM pace as
+            # SPEED in m/s (0:25/100m -> 4.0). Convert swim m/s -> min/100m; use the
+            # run pace directly. (Sending swim as min/100m stored a bogus speed, #88.)
             if is_swim:
-                if isinstance(pace_units, str) and pace_units in _SWIM_PACE_UNITS_SECONDS:
-                    normalized["swim_threshold"] = threshold_pace / 60.0
-                elif normalized.get("swim_threshold") is None:
-                    normalized["swim_threshold"] = threshold_pace
+                if normalized.get("swim_threshold") is None:
+                    normalized["swim_threshold"] = (
+                        (100.0 / threshold_pace) / 60.0 if threshold_pace else None
+                    )
             elif normalized.get("pace_threshold") is None:
                 normalized["pace_threshold"] = threshold_pace
 

--- a/src/intervals_icu_mcp/sport_settings_format.py
+++ b/src/intervals_icu_mcp/sport_settings_format.py
@@ -23,15 +23,12 @@ def format_sport_settings_entry(
     if settings.fthr is not None:
         sport_info["fthr_bpm"] = settings.fthr
     if settings.pace_threshold is not None:
-        pace_secs = settings.pace_threshold * 60
-        minutes = int(pace_secs // 60)
-        seconds = int(pace_secs % 60)
-        sport_info["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
+        total = round(settings.pace_threshold * 60)
+        sport_info["pace_threshold"] = f"{total // 60}:{total % 60:02d} /km"
     if settings.swim_threshold is not None:
-        swim_secs = settings.swim_threshold * 60
-        minutes = int(swim_secs // 60)
-        seconds = int(swim_secs % 60)
-        sport_info["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
+        # round, not truncate — the m/s <-> min/100m conversion adds tiny float error
+        total = round(settings.swim_threshold * 60)
+        sport_info["swim_threshold"] = f"{total // 60}:{total % 60:02d} /100m"
     return sport_info
 
 
@@ -66,7 +63,11 @@ def build_sport_settings_api_payload(
         payload["pace_units"] = "MINS_KM"
         payload["pace_load_type"] = "RUN"
     if swim_threshold is not None:
-        payload["threshold_pace"] = swim_threshold * 60
+        # Intervals.icu stores swim threshold as SPEED in m/s (unlike run, which is
+        # min/km). Convert min/100m -> m/s: 100 m / (minutes * 60) s. Sending the
+        # pace value directly stored a bogus speed (4.0 -> 4 m/s -> 0:25/100m); the
+        # old `* 60` sent seconds the API rejects with HTTP 422 (see #88).
+        payload["threshold_pace"] = 100.0 / (swim_threshold * 60) if swim_threshold else 0.0
         payload["pace_units"] = "SECS_100M"
         payload["pace_load_type"] = "SWIM"
     return payload

--- a/tests/test_athlete_branches.py
+++ b/tests/test_athlete_branches.py
@@ -102,7 +102,7 @@ class TestAthleteProfileSportSettings:
                         {
                             "id": 3,
                             "types": ["Swim"],
-                            "threshold_pace": 95,
+                            "threshold_pace": 100 / 120,  # m/s for 2:00/100m
                             "pace_units": "SECS_100M",
                             "pace_load_type": "SWIM",
                         },
@@ -121,7 +121,7 @@ class TestAthleteProfileSportSettings:
         assert ride["ftp_watts"] == 260
         assert ride["indoor_ftp_watts"] == 250
         swim = next(s for s in sports if s["type"] == "Swim")
-        assert swim["swim_threshold"] == "1:35 /100m"
+        assert swim["swim_threshold"] == "2:00 /100m"
 
 
 class TestAthleteProfileErrors:

--- a/tests/test_multi_athlete_and_models.py
+++ b/tests/test_multi_athlete_and_models.py
@@ -272,22 +272,32 @@ class TestSportSettingsModelMapping:
         assert settings.indoor_ftp == 232
         assert settings.fthr == 176
 
-    def test_sport_settings_maps_swim_threshold_from_seconds(self):
+    def test_sport_settings_maps_swim_threshold_from_mps(self):
         from intervals_icu_mcp.models import SportSettings
 
+        # API stores swim threshold as SPEED (m/s); 1:30/100m == 100/90 m/s -> 1.5 min.
         settings = SportSettings.model_validate(
             {
                 "id": 3,
                 "types": ["Swim"],
-                "threshold_pace": 90,
+                "threshold_pace": 100 / 90,
                 "pace_units": "SECS_100M",
                 "pace_load_type": "SWIM",
             }
         )
 
         assert settings.type == "Swim"
-        assert settings.swim_threshold == 1.5
+        assert settings.swim_threshold == pytest.approx(1.5)
         assert settings.pace_threshold is None
+
+    def test_build_sport_settings_api_payload_swim_sends_mps(self):
+        from intervals_icu_mcp.sport_settings_format import build_sport_settings_api_payload
+
+        # 1:30/100m (1.5 min) is stored as SPEED: 100 m / 90 s = 100/90 m/s.
+        payload = build_sport_settings_api_payload(swim_threshold=1.5)
+        assert payload["threshold_pace"] == pytest.approx(100 / 90)
+        assert payload["pace_units"] == "SECS_100M"
+        assert payload["pace_load_type"] == "SWIM"
 
     def test_build_sport_settings_api_payload_rejects_both_pace_params(self):
         from intervals_icu_mcp.sport_settings_format import build_sport_settings_api_payload

--- a/tests/test_sport_settings_tools.py
+++ b/tests/test_sport_settings_tools.py
@@ -32,7 +32,7 @@ RUN_SETTINGS = {
 SWIM_SETTINGS = {
     "id": 3,
     "types": ["Swim"],
-    "threshold_pace": 90,
+    "threshold_pace": 100 / 90,  # m/s for 1:30/100m
     "pace_units": "SECS_100M",
     "pace_load_type": "SWIM",
 }


### PR DESCRIPTION
Fixes #88.

## Problem

`icu_update_sport_settings` / `icu_create_sport_settings` could not set a swim CSS. The write path multiplied the pace by 60 and sent seconds (`240` for 4:00/100m), which the live API rejects:

```
HTTP 422: Invalid threshold pace: 240.0
```

## Root cause

Intervals.icu stores the swim threshold as **speed in m/s** — *not* a pace, and unlike run, which is min/km. Confirmed against the live API and the Intervals.icu UI: a stored `threshold_pace: 4.0` renders as `0:25/100m` (= 4 m/s: 100 m in 25 s), and the swim tempo zones are percentages of that *speed* (higher % = faster). The endpoint accepts `threshold_pace` up to ~40 (a sane m/s ceiling) and 422s above — which is why every realistic pace in seconds (60–240) was refused.

## Fix

Convert `min/100m ↔ m/s` on the swim path, both write and read: `mps = 100 / (min × 60)`. Run is unchanged (min/km, sent directly). Also **round** (not truncate) the pace/swim display, since the m/s round-trip introduces sub-second float error (`1.5 → 1:29` became `1:30`).

## Verification

Live end-to-end through the actual tool:

```
set 1.5 -> "1:30 /100m"   (raw 1.1111 m/s)
set 2.0 -> "2:00 /100m"   (raw 0.8333 m/s)
set 4.0 -> "4:00 /100m"   (raw 0.4167 m/s)   # was HTTP 422
```

Confirmed in the Intervals.icu UI (Schwellentempo renders `4:00/100m` for a stored `0.4167` m/s). `make can-release` green; sport-settings/model tests updated to the m/s convention, plus a write-payload assertion. Separate from #86 (workout authoring).
