### PR TITLE
docs(skills): document squash-only merge policy

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -35,7 +35,7 @@ No exceptions: trivial fixes, doc tweaks, one-liners — all go through a non-ma
 - Format: `type(scope): description` — [Conventional Commits](https://www.conventionalcommits.org).
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`.
 - Scope is optional but encouraged. Conventional scopes here: `tools`, `client`, `middleware`, `models`, `wellness`, `events`, `ci`, `release`, or a specific tool module name.
-- Do not put issue refs (`Closes #N`) in the commit message — those live in the PR body so GitHub auto-closes correctly on merge.
+- Do not put issue refs (`Closes #N`) in the commit message — those live in the PR body so GitHub auto-closes correctly on merge (and squash merges use a blank commit body, so commit-message refs would be dropped anyway).
 
 ## Doc + count sync
 
@@ -76,7 +76,7 @@ When opening a PR (`gh pr create` or user asks for one), put a closing keyword i
 
 Find the issue # in the user's prompt, branch name, or recent conversation. If unclear, ask — don't guess. After creating, verify with `gh pr view <n> --json closingIssuesReferences`; if empty, fix with `gh pr edit <n> --body-file -`.
 
-PR title follows the same conventional-commit format as the commit message. Body uses the existing `.github/PULL_REQUEST_TEMPLATE.md` structure (Summary / Changes / Checklist / Test plan).
+**The PR title becomes the `main` commit.** The repo is squash-only (settings: commit title from `PR_TITLE`, body `BLANK`): on merge, `main` gets exactly one commit whose subject is the PR title plus an appended ` (#N)`, and the branch's individual commits fold away. So write the PR title as you would a commit subject — single line, conventional format, ideally ≤ 70 chars to leave room for the ` (#N)` suffix — and edit non-conforming community PR titles *before* merging. Body uses the existing `.github/PULL_REQUEST_TEMPLATE.md` structure (Summary / Changes / Checklist / Test plan).
 
 ## Instructions
 

--- a/.claude/skills/release-check/SKILL.md
+++ b/.claude/skills/release-check/SKILL.md
@@ -25,10 +25,11 @@ allowed-tools: Bash(make can-release), Bash(make test:*), Bash(make lint:*)
    ```
    Every **user-facing** change (feat, fix, breaking change — including merged community
    PRs) must have a bullet under `## [Unreleased]`. Internal-only commits (ci, chore,
-   docs about the repo itself, release/publish plumbing) don't need entries. For each
+   docs about the repo itself, release/publish plumbing) don't need entries. PRs are
+   squash-merged, so each `main` commit maps 1:1 to a PR via its ` (#N)` suffix. For each
    user-facing commit with no matching bullet, report it as a failure and draft a
-   suggested entry (source it from the commit's PR description via `gh pr view` if one
-   exists).
+   suggested entry (source it from the PR description via `gh pr view N`, taking N from
+   the commit subject's suffix).
 
 3. Parse the output and report a clear summary:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,10 @@ The following skills are available in `.claude/skills/`:
 
 **Always run `make can-release` before finishing any feature work.** This runs the full test and lint suite, matching what CI checks on every push.
 
+## Merging PRs
+
+PRs are **squash-merged only** (repo setting: commit title from `PR_TITLE`, body `BLANK`). The PR title becomes the single `main` commit subject with ` (#N)` appended — write PR titles as single-line conventional commits (≤ ~70 chars), and edit non-conforming community PR titles before merging.
+
 ## Releases
 
 CHANGELOG.md is **manual** — there is no automated changelog generation. Entries are the **maintainer's responsibility**: community PRs deliberately do not include them (CONTRIBUTING.md and the PR template say so, to avoid `[Unreleased]` merge conflicts and keep SemVer classification in one place). Add the `[Unreleased]` bullet at merge time, while the PR context is fresh; `/release-check` verifies every user-facing commit since the last tag has an entry before a release is cut. The only release-related automation:


### PR DESCRIPTION
## Summary
The repo switched to squash-only merges (commit title from PR title, blank body). Document the consequences where future sessions will look:

- `/commit`: PR titles become the `main` commit subject verbatim + ` (#N)` — write them as commit subjects, fix community PR titles before merging; issue refs in commit messages would be dropped by the blank squash body (PR body was already the rule).
- `/release-check`: each `main` commit now maps 1:1 to a PR via the ` (#N)` suffix — draft missing CHANGELOG entries from `gh pr view N`.
- `CLAUDE.md`: one-paragraph merge-policy section.

Docs-only; no CHANGELOG entry (repo-internal).