### PR TITLE
chore(glama): add maintainer metadata file

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["hhopke"]
+}


### PR DESCRIPTION
## Summary
Adds the `glama.json` metadata file the Glama directory looks for (their score report cites its absence as a documentation gap). Declares `hhopke` as maintainer per their schema.

Merging also pushes a fresh commit to `main`, which re-triggers Glama's automatic build — their last build (for 89e804b) died in a transient Docker Hub metadata timeout on their infra before reaching our code, and the dashboard offers no manual retry.

Repo-internal metadata; no CHANGELOG entry.