### PR TITLE
fix(models): coerce null API list/dict fields to safe defaults

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal, cast
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Type aliases for common enums
 ActivityType = Literal["Ride", "Run", "Swim", "Walk", "Hike", "VirtualRide", "VirtualRun", "Other"]
@@ -103,6 +103,11 @@ class Athlete(BaseModel):
         default_factory=list[SportSettings],
         validation_alias=AliasChoices("sport_settings", "sportSettings"),
     )
+
+    @field_validator("sport_settings", mode="before")
+    @classmethod
+    def _coerce_sport_settings(cls, v: Any) -> list[Any]:
+        return v or []
 
 
 class AthleteProfile(BaseModel):
@@ -256,6 +261,11 @@ class Wellness(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    @field_validator("sport_info", mode="before")
+    @classmethod
+    def _coerce_sport_info(cls, v: Any) -> list[Any]:
+        return v or []
+
 
 # ==================== Event/Calendar Models ====================
 
@@ -357,6 +367,11 @@ class CurveData(BaseModel):
     days: int | None = None
     weight: float | None = None
 
+    @field_validator("secs", "values", "activity_id", "watts_per_kg", mode="before")
+    @classmethod
+    def _coerce_lists(cls, v: Any) -> list[Any]:
+        return v or []
+
 
 class CurveSet(BaseModel):
     """Wrapper returned by all curve API endpoints (power, HR, pace)."""
@@ -364,6 +379,11 @@ class CurveSet(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     curves: list[CurveData] = Field(default_factory=lambda: list[CurveData](), alias="list")
+
+    @field_validator("curves", mode="before")
+    @classmethod
+    def _coerce_curves(cls, v: Any) -> list[Any]:
+        return v or []
 
 
 # ==================== Training Plan Models ====================
@@ -405,6 +425,11 @@ class FitnessSummary(BaseModel):
     date: str | None = None
     interpretation: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("interpretation", mode="before")
+    @classmethod
+    def _coerce_interpretation(cls, v: Any) -> dict[str, Any]:
+        return v or {}
+
 
 # ==================== Activity Interval Models ====================
 
@@ -439,6 +464,11 @@ class IntervalsDTO(BaseModel):
     id: str | None = None
     icu_intervals: list[Interval] = Field(default_factory=lambda: list[Interval]())
 
+    @field_validator("icu_intervals", mode="before")
+    @classmethod
+    def _coerce_icu_intervals(cls, v: Any) -> list[Any]:
+        return v or []
+
 
 # ==================== Activity Streams Models ====================
 
@@ -470,6 +500,11 @@ class BestEfforts(BaseModel):
     """Response from the best-efforts endpoint."""
 
     efforts: list[Effort] = Field(default_factory=lambda: list[Effort]())
+
+    @field_validator("efforts", mode="before")
+    @classmethod
+    def _coerce_efforts(cls, v: Any) -> list[Any]:
+        return v or []
 
 
 # ==================== Gear Models ====================
@@ -507,6 +542,11 @@ class Gear(BaseModel):
     reminders: list[GearReminder] = Field(default_factory=list[GearReminder])
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("reminders", mode="before")
+    @classmethod
+    def _coerce_reminders(cls, v: Any) -> list[Any]:
+        return v or []
 
 
 # ==================== Histogram Models ====================

--- a/tests/test_multi_athlete_and_models.py
+++ b/tests/test_multi_athlete_and_models.py
@@ -330,6 +330,62 @@ class TestSportSettingsModelMapping:
         assert athlete.sport_settings[0].fthr == 165
 
 
+class TestNullListDictFieldCoercion:
+    """Several endpoints return explicit `null` (not a missing key) for list/dict fields
+    when there's no computed data yet for that record — e.g. sportInfo on wellness days
+    without processed activities. Pydantic's `default_factory` only applies when the key
+    is absent, so each of these fields needs a `mode="before"` validator to coerce None
+    to an empty list/dict instead of raising a validation error. Wellness.sport_info has
+    its own dedicated test in test_wellness_tools.py; this covers the rest."""
+
+    def test_athlete_handles_null_sport_settings(self):
+        from intervals_icu_mcp.models import Athlete
+
+        athlete = Athlete.model_validate({"id": "i123456", "name": "Test", "sportSettings": None})
+        assert athlete.sport_settings == []
+
+    def test_curve_data_handles_null_list_fields(self):
+        from intervals_icu_mcp.models import CurveData
+
+        curve = CurveData.model_validate(
+            {"secs": None, "values": None, "activity_id": None, "watts_per_kg": None}
+        )
+        assert curve.secs == []
+        assert curve.values == []
+        assert curve.activity_id == []
+        assert curve.watts_per_kg == []
+
+    def test_curve_set_handles_null_curves(self):
+        from intervals_icu_mcp.models import CurveSet
+
+        curve_set = CurveSet.model_validate({"list": None})
+        assert curve_set.curves == []
+
+    def test_fitness_summary_handles_null_interpretation(self):
+        from intervals_icu_mcp.models import FitnessSummary
+
+        summary = FitnessSummary.model_validate({"interpretation": None})
+        assert summary.interpretation == {}
+
+    def test_intervals_dto_handles_null_icu_intervals(self):
+        from intervals_icu_mcp.models import IntervalsDTO
+
+        dto = IntervalsDTO.model_validate({"icu_intervals": None})
+        assert dto.icu_intervals == []
+
+    def test_best_efforts_handles_null_efforts(self):
+        from intervals_icu_mcp.models import BestEfforts
+
+        efforts = BestEfforts.model_validate({"efforts": None})
+        assert efforts.efforts == []
+
+    def test_gear_handles_null_reminders(self):
+        from intervals_icu_mcp.models import Gear
+
+        gear = Gear.model_validate({"id": "b123", "reminders": None})
+        assert gear.reminders == []
+
+
 class TestPydanticAliases:
     """Test that icu_average_watts / icu_weighted_avg_watts map correctly."""
 

--- a/tests/test_wellness_tools.py
+++ b/tests/test_wellness_tools.py
@@ -256,3 +256,15 @@ class TestWellnessTools:
         record = Wellness.model_validate({"id": "2026-04-20", "weight": 70.0, "futureMetric": 42})
         # Unknown field is preserved (not silently dropped)
         assert getattr(record, "futureMetric", None) == 42
+
+    def test_wellness_handles_null_sport_info(self):
+        """API returns sportInfo: null for days without computed sport metrics —
+        this should not crash parsing."""
+        from intervals_icu_mcp.models import Wellness
+
+        raw = {
+            "id": "2026-07-09",
+            "sportInfo": None,
+        }
+        wellness = Wellness.model_validate(raw)
+        assert wellness.sport_info == []


### PR DESCRIPTION
## What
`Wellness.sport_info` (and 7 other list/dict fields across models.py) used `default_factory`
for their defaults, but Pydantic's `default_factory` only kicks in when the field is *absent*
from the input — not when it's explicitly `null`. Intervals.icu's API returns `"sportInfo": null`
for any day without computed sport metrics (eFTP/W'/Pmax), which is the common case, so every
`icu_update_wellness` call was crashing with:

    Unexpected error: 1 validation error for Wellness
    sportInfo
      Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]

## Fix
Added `mode="before"` field validators that coerce `None` → `[]` (or `{}` for dict fields)
before Pydantic's list/dict validation runs. Applied to every field with the same pattern,
found via `grep -n default_factory src/intervals_icu_mcp/models.py`:
`Athlete.sport_settings`, `Wellness.sport_info`, `CurveData.{secs,values,activity_id,watts_per_kg}`,
`CurveSet.curves`, `FitnessSummary.interpretation`, `IntervalsDTO.icu_intervals`,
`BestEfforts.efforts`, `Gear.reminders`.

## Testing
Added `test_wellness_handles_null_sport_info` (test_wellness_tools.py) reproducing the exact
null-payload crash, plus a `TestNullListDictFieldCoercion` class in
test_multi_athlete_and_models.py covering the remaining 7 fields' null-branch with the same
pattern. Verified against the live Intervals.icu API — `icu_update_wellness` calls that
previously failed now succeed.

`make can-release` passes locally (tests, ruff, pyright, package check).