### PR TITLE
fix(client): fetch folder workouts via library list to fix HTTP 405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ that preserve the information (key renames, restructuring, added fields) ship in
 clients. (Releases up to and including 4.0.0 treated any response-shape change as
 breaking; this narrower contract applies from the next release onward.)
 
+## [Unreleased]
+
+### Fixed
+- `icu_get_workouts_in_folder` failed with HTTP 405 for every folder and training plan — broken since the initial release. It called `GET /athlete/{id}/folders/{folderId}/workouts`, but that Intervals.icu path is PUT-only (a bulk-update operation); the API has no per-folder listing endpoint at all. The client now fetches the athlete's full workout library (`GET /athlete/{id}/workouts`) and filters by `folder_id`. Verified against the live API. Reported by @gadelain (#95).
+
 ## [4.3.1] — 2026-07-21
 
 ### Fixed

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -892,9 +892,12 @@ class ICUClient:
             List of Workout objects
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        response = await self._request("GET", f"/athlete/{athlete_id}/folders/{folder_id}/workouts")
+        # The API has no GET on /folders/{folderId}/workouts (that path is PUT-only),
+        # so fetch the whole library and filter by folder_id.
+        response = await self._request("GET", f"/athlete/{athlete_id}/workouts")
         adapter = TypeAdapter(list[Workout])
-        return adapter.validate_python(response.json())
+        workouts = adapter.validate_python(response.json())
+        return [w for w in workouts if w.folder_id == folder_id]
 
     # ==================== Event Write Operations ====================
 

--- a/tests/test_workout_library_tools.py
+++ b/tests/test_workout_library_tools.py
@@ -116,7 +116,7 @@ class TestGetWorkoutsInFolder:
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
-        respx_mock.get("/athlete/i123456/folders/1/workouts").mock(
+        respx_mock.get("/athlete/i123456/workouts").mock(
             return_value=Response(
                 200,
                 json=[
@@ -125,6 +125,7 @@ class TestGetWorkoutsInFolder:
                         "name": "Threshold Intervals",
                         "description": "5x5min @ FTP",
                         "type": "Ride",
+                        "folder_id": 1,
                         "moving_time": 3600,
                         "distance": 30000.0,
                         "icu_training_load": 100,
@@ -137,8 +138,15 @@ class TestGetWorkoutsInFolder:
                     {
                         "id": 101,
                         "name": "Easy Spin",
+                        "folder_id": 1,
                         "moving_time": 1800,
                         "indoor": False,
+                    },
+                    {
+                        "id": 102,
+                        "name": "Other Folder Workout",
+                        "folder_id": 7,
+                        "moving_time": 900,
                     },
                 ],
             )
@@ -149,6 +157,7 @@ class TestGetWorkoutsInFolder:
         response = json.loads(result)
         data = response["data"]
         assert data["folder_id"] == 1
+        # Workout 102 lives in folder 7 and must be filtered out
         assert len(data["workouts"]) == 2
         threshold = data["workouts"][0]
         assert threshold["metrics"]["training_load"] == 100
@@ -171,8 +180,8 @@ class TestGetWorkoutsInFolder:
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
-        respx_mock.get("/athlete/i123456/folders/2/workouts").mock(
-            return_value=Response(200, json=[{"id": 200, "name": "Placeholder"}])
+        respx_mock.get("/athlete/i123456/workouts").mock(
+            return_value=Response(200, json=[{"id": 200, "name": "Placeholder", "folder_id": 2}])
         )
 
         result = await get_workouts_in_folder(folder_id=2, ctx=mock_ctx)
@@ -183,8 +192,9 @@ class TestGetWorkoutsInFolder:
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
-        respx_mock.get("/athlete/i123456/folders/99/workouts").mock(
-            return_value=Response(200, json=[])
+        # A non-empty library where nothing belongs to folder 99
+        respx_mock.get("/athlete/i123456/workouts").mock(
+            return_value=Response(200, json=[{"id": 300, "name": "Elsewhere", "folder_id": 1}])
         )
 
         result = await get_workouts_in_folder(folder_id=99, ctx=mock_ctx)
@@ -197,9 +207,7 @@ class TestGetWorkoutsInFolder:
         mock_ctx = MagicMock()
         mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
-        respx_mock.get("/athlete/i123456/folders/1/workouts").mock(
-            return_value=Response(404, json={})
-        )
+        respx_mock.get("/athlete/i123456/workouts").mock(return_value=Response(404, json={}))
 
         result = await get_workouts_in_folder(folder_id=1, ctx=mock_ctx)
         response = json.loads(result)


### PR DESCRIPTION
## Summary

Fixes #95

`icu_get_workouts_in_folder` failed with HTTP 405 Method Not Allowed for every folder and training plan — broken since the initial release. The client called `GET /athlete/{id}/folders/{folderId}/workouts`, but per the Intervals.icu OpenAPI spec that path only supports **PUT** ("Update a range of workouts on a plan") — it has never supported GET, and the API has no per-folder listing endpoint at all. The correct source is `GET /athlete/{id}/workouts` (the full library list), where each workout carries a `folder_id` field.

## Changes

- `client.get_workouts_in_folder()` now fetches `GET /athlete/{id}/workouts` and filters the result by `folder_id` (tool interface and response shape unchanged)
- Updated the respx tests to mock the library-list endpoint, including a cross-folder workout that must be filtered out
- CHANGELOG entry under `[Unreleased]`

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/` (n/a — no new tools)
- [x] Public-facing behavior changes are reflected in the README or `docs/` (n/a — no docs referenced the old endpoint)
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate (n/a)
- [x] No API keys, athlete IDs, or other credentials are committed

## Test plan

- 318 unit tests pass (`make can-release` green)
- Verified live against the real Intervals.icu API: reproduced the 405 on the old path, then with the fix created a throwaway workout in a real folder, confirmed `get_workouts_in_folder(<folder_id>)` returns it (and returns `[]` for a different folder id), and deleted the probe workout afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)