### PR TITLE
fix(wellness): surface custom wellness fields in responses

### DIFF
--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -166,6 +166,14 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
     if getattr(record, "comments", None):
         day_data["comments"] = record.comments
 
+    # Athlete-defined wellness fields are not part of the static Wellness
+    # schema. Pydantic keeps them in model_extra (Wellness uses extra="allow");
+    # surface them verbatim instead of silently dropping them while formatting.
+    model_extra: dict[str, Any] = getattr(record, "model_extra", None) or {}
+    custom_fields = {name: value for name, value in model_extra.items() if value is not None}
+    if custom_fields:
+        day_data["custom_fields"] = custom_fields
+
     return day_data
 
 

--- a/tests/test_wellness_tools.py
+++ b/tests/test_wellness_tools.py
@@ -257,6 +257,59 @@ class TestWellnessTools:
         # Unknown field is preserved (not silently dropped)
         assert getattr(record, "futureMetric", None) == 42
 
+    async def test_get_wellness_for_date_surfaces_custom_fields(self, mock_config, respx_mock):
+        """Athlete-defined wellness fields survive MCP response formatting."""
+        custom_fields = {
+            "REMSleep": 7200,
+            "DeepSleep": 5400,
+            "LightSleep": 14400,
+            "ActiveEnergy": 850,
+            "RestingEnergy": 1750,
+            "LeanBodyMass": 61.5,
+        }
+        respx_mock.get("/athlete/i123456/wellness/2026-04-20").mock(
+            return_value=Response(
+                200,
+                json={"id": "2026-04-20", **custom_fields},
+            )
+        )
+
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+        result = await get_wellness_for_date(date="2026-04-20", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["custom_fields"] == custom_fields
+
+    async def test_get_wellness_data_surfaces_custom_fields_including_zero(
+        self, mock_config, respx_mock
+    ):
+        """Range responses retain valid falsy custom-field values."""
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(
+                200,
+                json=[
+                    {
+                        "id": "2026-04-20",
+                        "REMSleep": 0,
+                        "ActiveEnergy": 0,
+                        "LeanBodyMass": 61.5,
+                    }
+                ],
+            )
+        )
+
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+        result = await get_wellness_data(days_back=1, ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["wellness_data"][0]["custom_fields"] == {
+            "REMSleep": 0,
+            "ActiveEnergy": 0,
+            "LeanBodyMass": 61.5,
+        }
+
     def test_wellness_handles_null_sport_info(self):
         """API returns sportInfo: null for days without computed sport metrics —
         this should not crash parsing."""


### PR DESCRIPTION
## Summary

Intervals.icu returns athlete-defined wellness fields after they are configured, but the MCP formatter silently dropped them even though the Pydantic model preserved them.

## Changes

- Surface unknown wellness fields under a `custom_fields` object using their original Intervals.icu names.
- Preserve valid falsy values such as `0`, while omitting only `null` values.
- Add coverage for both single-date and range responses, including REMSleep, DeepSleep, LightSleep, ActiveEnergy, RestingEnergy, and LeanBodyMass.

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright, package checks)
- [x] Regression tests added in `tests/test_wellness_tools.py`
- [x] No API keys, athlete IDs, or other credentials are committed
- [x] No new MCP tools or destructive operations are introduced

## Test plan

- `make can-release`
- 320 tests passed
- Ruff passed
- Pyright: 0 errors
- Wheel and source distribution passed strict metadata checks
- Pyroma rating: 10/10
