### PR TITLE
fix(client): send required interval-search params to fix HTTP 422

### DIFF
--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -869,35 +869,41 @@ class ICUClient:
         interval_type: str | None = None,
         min_duration: int | None = None,
         max_duration: int | None = None,
+        min_intensity: int | None = None,
+        max_intensity: int | None = None,
         limit: int = 30,
     ) -> list[dict[str, Any]]:
         """Search for intervals across activities.
 
         Args:
             athlete_id: Athlete ID (uses config default if not provided)
-            interval_type: Type of interval to search for
-            min_duration: Minimum duration in seconds
-            max_duration: Maximum duration in seconds
-            limit: Maximum number of results to return
+            interval_type: Interval target type: AUTO, POWER, HR, or PACE
+            min_duration: Minimum interval duration in seconds
+            max_duration: Maximum interval duration in seconds
+            min_intensity: Minimum interval intensity in percent of threshold
+            max_intensity: Maximum interval intensity in percent of threshold
+            limit: Maximum number of matching activities to return
 
         Returns:
-            List of matching intervals with activity context
+            List of matching activities, each with a summary of the intervals found
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
-
+        # The API rejects the request with HTTP 422 unless all four bounds are
+        # present, so unset bounds fall back to the widest accepted range.
+        params: dict[str, Any] = {
+            "minSecs": min_duration if min_duration is not None else 0,
+            "maxSecs": max_duration if max_duration is not None else 86400,
+            "minIntensity": min_intensity if min_intensity is not None else 0,
+            "maxIntensity": max_intensity if max_intensity is not None else 999,
+            "limit": limit,
+        }
         if interval_type:
             params["type"] = interval_type
-        if min_duration:
-            params["minDuration"] = min_duration
-        if max_duration:
-            params["maxDuration"] = max_duration
 
         response = await self._request(
             "GET", f"/athlete/{athlete_id}/activities/interval-search", params=params
         )
-        results = response.json()
-        return results[:limit]
+        return response.json()
 
     # ==================== Workout Library Endpoints ====================
 

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -275,11 +275,37 @@ async def get_best_efforts(
         )
 
 
+_INTERVAL_TARGET_TYPES = {"AUTO", "POWER", "HR", "PACE"}
+
+# The API returns full Activity objects (~180 fields each); only these carry
+# information about the interval match itself or identify the activity.
+_INTERVAL_SEARCH_FIELDS = [
+    "id",
+    "name",
+    "type",
+    "start_date_local",
+    "distance",
+    "moving_time",
+    "icu_training_load",
+    "interval_summary",
+]
+
+
 async def search_intervals(
-    interval_type: Annotated[str | None, "Type of interval to search for"] = None,
-    min_duration: Annotated[int | None, "Minimum duration in seconds"] = None,
-    max_duration: Annotated[int | None, "Maximum duration in seconds"] = None,
-    limit: Annotated[int, "Maximum number of results to return"] = 30,
+    interval_type: Annotated[
+        str | None,
+        "Interval target type: AUTO, POWER, HR, or PACE (what the interval "
+        "targeted — not the sport and not a workout-step label)",
+    ] = None,
+    min_duration: Annotated[int | None, "Minimum interval duration in seconds"] = None,
+    max_duration: Annotated[int | None, "Maximum interval duration in seconds"] = None,
+    min_intensity: Annotated[
+        int | None, "Minimum interval intensity in percent of threshold (e.g. 80)"
+    ] = None,
+    max_intensity: Annotated[
+        int | None, "Maximum interval intensity in percent of threshold (e.g. 105)"
+    ] = None,
+    limit: Annotated[int, "Maximum number of matching activities to return"] = 30,
     athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
@@ -287,18 +313,29 @@ async def search_intervals(
 
     Different from icu_get_activity_intervals (single-activity). Use to track
     progress on a workout type ("all my threshold intervals over the last
-    year") or find comparable historical sessions.
+    year") or find comparable historical sessions. Returns the activities
+    containing matching intervals, each with an `interval_summary` like
+    "2x 8m 162w" (reps x duration at target).
     """
     assert ctx is not None
     config: ICUConfig = await ctx.get_state("config")
+
+    if interval_type and interval_type.upper() not in _INTERVAL_TARGET_TYPES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid interval_type '{interval_type}'. "
+            f"Must be one of: {', '.join(sorted(_INTERVAL_TARGET_TYPES))}.",
+            error_type="validation_error",
+        )
 
     try:
         async with ICUClient(config) as client:
             results = await client.search_intervals(
                 athlete_id=athlete_id,
-                interval_type=interval_type,
+                interval_type=interval_type.upper() if interval_type else None,
                 min_duration=min_duration,
                 max_duration=max_duration,
+                min_intensity=min_intensity,
+                max_intensity=max_intensity,
                 limit=limit,
             )
 
@@ -310,21 +347,32 @@ async def search_intervals(
                     search_criteria.append(f"min_duration={min_duration}s")
                 if max_duration:
                     search_criteria.append(f"max_duration={max_duration}s")
+                if min_intensity:
+                    search_criteria.append(f"min_intensity={min_intensity}%")
+                if max_intensity:
+                    search_criteria.append(f"max_intensity={max_intensity}%")
 
                 criteria_str = ", ".join(search_criteria) if search_criteria else "your criteria"
 
                 return ResponseBuilder.build_response(
-                    data={"intervals": [], "count": 0},
+                    data={"activities": [], "count": 0},
                     metadata={"message": f"No intervals found matching {criteria_str}"},
                 )
 
+            activities = [
+                {k: item.get(k) for k in _INTERVAL_SEARCH_FIELDS if item.get(k) is not None}
+                for item in results
+            ]
+
             result_data = {
-                "intervals": results,
-                "count": len(results),
+                "activities": activities,
+                "count": len(activities),
                 "search_criteria": {
                     "interval_type": interval_type,
                     "min_duration_seconds": min_duration,
                     "max_duration_seconds": max_duration,
+                    "min_intensity_percent": min_intensity,
+                    "max_intensity_percent": max_intensity,
                 },
             }
 

--- a/tests/test_activity_analysis_tools.py
+++ b/tests/test_activity_analysis_tools.py
@@ -261,34 +261,89 @@ class TestGetBestEfforts:
 
 class TestSearchIntervals:
     async def test_success_with_all_filters(self, mock_config, respx_mock):
+        """Filters map to the API's required param names (regression for #102)."""
         route = respx_mock.get("/athlete/i123456/activities/interval-search").mock(
             return_value=Response(
                 200,
                 json=[
-                    {"id": 1, "type": "WORK", "duration": 300, "activity_id": "a1"},
-                    {"id": 2, "type": "WORK", "duration": 600, "activity_id": "a2"},
+                    {
+                        "id": "i1",
+                        "name": "Sweet Spot 2x8",
+                        "type": "Ride",
+                        "start_date_local": "2026-04-08T20:54:11",
+                        "moving_time": 3622,
+                        "icu_training_load": 51,
+                        "interval_summary": ["2x 8m 162w"],
+                        "average_stride": 1.2,
+                        "athlete_max_hr": 190,
+                    },
+                    {
+                        "id": "i2",
+                        "name": "Threshold",
+                        "type": "Run",
+                        "interval_summary": ["4x 5m 4:10/km"],
+                    },
                 ],
             )
         )
 
         result = await search_intervals(
-            interval_type="WORK",
+            interval_type="power",
             min_duration=120,
             max_duration=1200,
+            min_intensity=80,
+            max_intensity=105,
             limit=10,
             ctx=_make_ctx(mock_config),
         )
 
         params = route.calls[0].request.url.params
-        assert params["type"] == "WORK"
-        assert params["minDuration"] == "120"
-        assert params["maxDuration"] == "1200"
+        assert params["type"] == "POWER"
+        assert params["minSecs"] == "120"
+        assert params["maxSecs"] == "1200"
+        assert params["minIntensity"] == "80"
+        assert params["maxIntensity"] == "105"
+        assert params["limit"] == "10"
 
         response = json.loads(result)
         data = response["data"]
         assert data["count"] == 2
-        assert data["search_criteria"]["interval_type"] == "WORK"
+        assert data["search_criteria"]["interval_type"] == "power"
         assert data["search_criteria"]["min_duration_seconds"] == 120
+        assert data["search_criteria"]["min_intensity_percent"] == 80
+        # Full Activity objects are projected down to the interval-relevant fields
+        first = data["activities"][0]
+        assert first["interval_summary"] == ["2x 8m 162w"]
+        assert "average_stride" not in first
+        assert "athlete_max_hr" not in first
+
+    async def test_required_params_sent_on_default_call(self, mock_config, respx_mock):
+        """The API 422s without all four bounds — a bare call must send defaults."""
+        route = respx_mock.get("/athlete/i123456/activities/interval-search").mock(
+            return_value=Response(200, json=[])
+        )
+
+        await search_intervals(ctx=_make_ctx(mock_config))
+
+        params = route.calls[0].request.url.params
+        assert params["minSecs"] == "0"
+        assert params["maxSecs"] == "86400"
+        assert params["minIntensity"] == "0"
+        assert params["maxIntensity"] == "999"
+        assert params["limit"] == "30"
+        assert "type" not in params
+
+    async def test_invalid_interval_type_rejected_before_api_call(self, mock_config, respx_mock):
+        """Values like WORK or Ride are not target types — fail fast, no request."""
+        route = respx_mock.get("/athlete/i123456/activities/interval-search").mock(
+            return_value=Response(200, json=[])
+        )
+
+        result = await search_intervals(interval_type="WORK", ctx=_make_ctx(mock_config))
+        response = json.loads(result)
+        assert response["error"]["type"] == "validation_error"
+        assert "AUTO" in response["error"]["message"]
+        assert not route.called
 
     async def test_no_results_with_criteria_string(self, mock_config, respx_mock):
         respx_mock.get("/athlete/i123456/activities/interval-search").mock(
@@ -296,11 +351,11 @@ class TestSearchIntervals:
         )
 
         result = await search_intervals(
-            interval_type="THRESHOLD", min_duration=600, ctx=_make_ctx(mock_config)
+            interval_type="PACE", min_duration=600, ctx=_make_ctx(mock_config)
         )
         response = json.loads(result)
         assert response["data"]["count"] == 0
-        assert "THRESHOLD" in response["metadata"]["message"]
+        assert "PACE" in response["metadata"]["message"]
         assert "600" in response["metadata"]["message"]
 
     async def test_no_results_no_criteria_uses_default_string(self, mock_config, respx_mock):
@@ -317,6 +372,6 @@ class TestSearchIntervals:
             return_value=Response(500, json={})
         )
 
-        result = await search_intervals(interval_type="WORK", ctx=_make_ctx(mock_config))
+        result = await search_intervals(interval_type="HR", ctx=_make_ctx(mock_config))
         response = json.loads(result)
         assert response["error"]["type"] == "api_error"


### PR DESCRIPTION
## Summary

Fixes #102 — `icu_search_intervals` returned HTTP 422 on every call since the initial release.

## Changes

- Send the API's required query params on every call: `minSecs`/`maxSecs` (previously misnamed `minDuration`/`maxDuration`) and `minIntensity`/`maxIntensity` (previously never sent). Unset bounds fall back to the widest accepted range (0–86400s, 0–999%), so a bare call works.
- Pass `limit` to the API instead of over-fetching and slicing client-side (verified the server honors it).
- Two findings beyond the issue's analysis, both live-verified:
  - `type` is **not** a free-form interval label — the API requires the enum `AUTO | POWER | HR | PACE` (interval *target* type) and 422s on anything else (e.g. `WORK`, `Ride`). The tool now documents the enum, normalizes case, and rejects invalid values with a clear `validation_error` before the HTTP call. New defaulted `min_intensity` / `max_intensity` params round out the filters (non-breaking, additive).
  - The endpoint returns **full Activity objects (~180 fields, ~4.6 KB each)** — 30 results would be ~140 KB per response. The tool now projects each hit down to the 8 interval-relevant fields (`id`, `name`, `type`, `start_date_local`, `distance`, `moving_time`, `icu_training_load`, `interval_summary`), under a `data.activities` key that reflects what the results actually are.

## Test plan

- `make can-release` passes (353 tests, ruff, pyright, packaging)
- New regression tests: required params always sent (bare call), param-name mapping, enum validation fails fast without an HTTP request, response projection drops the noise fields
- Live-verified end-to-end: bare call returns activities (previously 422); `interval_type="POWER", min_duration=300, min_intensity=80` returns the expected sweet-spot sessions with `interval_summary` like `2x 8m 162w`

🤖 Generated with [Claude Code](https://claude.com/claude-code)