### PR TITLE
fix(auth): stop rejecting real athlete id i123456

### DIFF
--- a/src/intervals_icu_mcp/auth.py
+++ b/src/intervals_icu_mcp/auth.py
@@ -61,7 +61,10 @@ def validate_credentials(config: ICUConfig) -> bool:
     """
     if not config.intervals_icu_api_key or config.intervals_icu_api_key == "your_api_key_here":
         return False
-    if not config.intervals_icu_athlete_id or config.intervals_icu_athlete_id == "i123456":
+    # Do not reject specific athlete id values: any non-empty id may belong to a
+    # real athlete (i123456 from .env.example is a valid id someone could own).
+    # The API is the authority on whether credentials actually work.
+    if not config.intervals_icu_athlete_id:
         return False
     return True
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,36 @@
+"""Tests for credential validation."""
+
+from intervals_icu_mcp.auth import ICUConfig, validate_credentials
+
+
+class TestValidateCredentials:
+    def test_accepts_athlete_id_i123456(self):
+        """i123456 is a real athlete id, not a reserved value — it must not be
+        rejected just because .env.example uses it (regression for #104)."""
+        config = ICUConfig(
+            intervals_icu_api_key="a_real_key",
+            intervals_icu_athlete_id="i123456",
+        )
+        assert validate_credentials(config) is True
+
+    def test_accepts_normal_credentials(self):
+        config = ICUConfig(
+            intervals_icu_api_key="a_real_key",
+            intervals_icu_athlete_id="i368404",
+        )
+        assert validate_credentials(config) is True
+
+    def test_rejects_missing_api_key(self):
+        config = ICUConfig(intervals_icu_api_key="", intervals_icu_athlete_id="i368404")
+        assert validate_credentials(config) is False
+
+    def test_rejects_placeholder_api_key(self):
+        config = ICUConfig(
+            intervals_icu_api_key="your_api_key_here",
+            intervals_icu_athlete_id="i368404",
+        )
+        assert validate_credentials(config) is False
+
+    def test_rejects_missing_athlete_id(self):
+        config = ICUConfig(intervals_icu_api_key="a_real_key", intervals_icu_athlete_id="")
+        assert validate_credentials(config) is False


### PR DESCRIPTION
## Summary

Fixes #104 — `validate_credentials()` special-cased the athlete id `i123456` as an unconfigured placeholder, so the (real) owner of that id could not use any tool: the check runs in `ConfigMiddleware` on every call and raises `ToolError` telling them to re-run auth, which writes the same id back.

## Changes

- Drop the `== "i123456"` check. A placeholder value in `.env.example` should not be special-cased at runtime — the API already answers authoritatively (403/404) for ids the key cannot access. The `your_api_key_here` placeholder check on the key is kept: unlike the athlete id, it cannot collide with a real credential.
- Add `tests/test_auth.py` covering the regression (i123456 accepted) plus the retained rejections (empty key/id, placeholder key).

## Test plan

- `make can-release` passes (356 tests, ruff, pyright, packaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)