### PR TITLE
fix(gear): call real reminder endpoints with real field names

### DIFF
--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -18,7 +18,6 @@ from .models import (
     Event,
     Folder,
     Gear,
-    GearReminder,
     Interval,
     IntervalsDTO,
     SportSettings,
@@ -1065,22 +1064,22 @@ class ICUClient:
         gear_id: str,
         reminder_data: dict[str, Any],
         athlete_id: str | None = None,
-    ) -> GearReminder:
+    ) -> Gear:
         """Create a new reminder for a gear item.
 
         Args:
             gear_id: Gear ID
-            reminder_data: Reminder data dictionary
+            reminder_data: Reminder data using API field names (name, distance, time, ...)
             athlete_id: Athlete ID (uses config default if not provided)
 
         Returns:
-            Created GearReminder object
+            The updated Gear object — the API returns the gear, not the reminder
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
         response = await self._request(
-            "POST", f"/athlete/{athlete_id}/gear/{gear_id}/reminders", json=reminder_data
+            "POST", f"/athlete/{athlete_id}/gear/{gear_id}/reminder", json=reminder_data
         )
-        return GearReminder(**response.json())
+        return Gear(**response.json())
 
     async def update_gear_reminder(
         self,
@@ -1088,25 +1087,25 @@ class ICUClient:
         reminder_id: int,
         reminder_data: dict[str, Any],
         athlete_id: str | None = None,
-    ) -> GearReminder:
+    ) -> Gear:
         """Update an existing gear reminder.
 
         Args:
             gear_id: Gear ID
             reminder_id: Reminder ID
-            reminder_data: Updated reminder data dictionary
+            reminder_data: Updated reminder data using API field names (name, distance, time, ...)
             athlete_id: Athlete ID (uses config default if not provided)
 
         Returns:
-            Updated GearReminder object
+            The updated Gear object — the API returns the gear, not the reminder
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
         response = await self._request(
             "PUT",
-            f"/athlete/{athlete_id}/gear/{gear_id}/reminders/{reminder_id}",
+            f"/athlete/{athlete_id}/gear/{gear_id}/reminder/{reminder_id}",
             json=reminder_data,
         )
-        return GearReminder(**response.json())
+        return Gear(**response.json())
 
     # ==================== Sport Settings Endpoints ====================
 

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -511,16 +511,30 @@ class BestEfforts(BaseModel):
 
 
 class GearReminder(BaseModel):
-    """Gear maintenance reminder."""
+    """Gear maintenance reminder.
+
+    Mirrors the API schema: `distance` (m), `time` (s), `activities`, and
+    `days` are recurring trigger thresholds (0 = threshold unused); the
+    `*_used` fields track consumption since `last_reset`.
+    """
 
     id: int
-    text: str | None = None
-    distance_alert: float | None = Field(None, alias="distance_alert")
-    time_alert: int | None = Field(None, alias="time_alert")
-    due_distance: float | None = Field(None, alias="due_distance")
-    due_time: int | None = Field(None, alias="due_time")
-    is_due: bool | None = Field(None, alias="is_due")
-    snoozed_until: str | None = Field(None, alias="snoozed_until")
+    gear_id: str | None = None
+    name: str | None = None
+    distance: float | None = None
+    time: float | None = None
+    activities: int | None = None
+    days: int | None = None
+    last_reset: str | None = None
+    starting_distance: float | None = None
+    starting_time: float | None = None
+    starting_activities: int | None = None
+    snoozed_until: str | None = None
+    percent_used: float | None = None
+    distance_used: float | None = None
+    time_used: float | None = None
+    activities_used: int | None = None
+    days_used: int | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/src/intervals_icu_mcp/tools/gear.py
+++ b/src/intervals_icu_mcp/tools/gear.py
@@ -65,27 +65,26 @@ async def get_gear_list(
                     for reminder in gear.reminders:
                         reminder_info: dict[str, Any] = {
                             "id": reminder.id,
-                            "text": reminder.text,
+                            "text": reminder.name,
                         }
 
-                        # Alert thresholds
-                        if reminder.distance_alert is not None:
-                            reminder_info["alert_every_km"] = round(
-                                reminder.distance_alert / 1000, 2
-                            )
-                        if reminder.time_alert is not None:
-                            hours = reminder.time_alert // 3600
-                            reminder_info["alert_every_hours"] = hours
+                        # Recurring trigger thresholds (API sends 0 for unused)
+                        if reminder.distance:
+                            reminder_info["alert_every_km"] = round(reminder.distance / 1000, 2)
+                        if reminder.time:
+                            reminder_info["alert_every_hours"] = int(reminder.time // 3600)
+                        if reminder.activities:
+                            reminder_info["alert_every_activities"] = reminder.activities
+                        if reminder.days:
+                            reminder_info["alert_every_days"] = reminder.days
 
-                        # Due status
-                        if reminder.is_due is not None:
-                            reminder_info["is_due"] = reminder.is_due
-
-                        if reminder.due_distance is not None:
-                            reminder_info["due_in_km"] = round(reminder.due_distance / 1000, 2)
-                        if reminder.due_time is not None:
-                            hours = reminder.due_time // 3600
-                            reminder_info["due_in_hours"] = hours
+                        # Consumption since the reminder was last reset
+                        if reminder.percent_used is not None:
+                            reminder_info["percent_used"] = round(reminder.percent_used, 1)
+                        if reminder.distance and reminder.distance_used is not None:
+                            reminder_info["used_km"] = round(reminder.distance_used / 1000, 2)
+                        if reminder.time and reminder.time_used is not None:
+                            reminder_info["used_hours"] = round(reminder.time_used / 3600, 1)
 
                         if reminder.snoozed_until:
                             reminder_info["snoozed_until"] = reminder.snoozed_until
@@ -288,15 +287,14 @@ async def create_gear_reminder(
 
     try:
         async with ICUClient(config) as client:
-            reminder_data: dict[str, Any] = {"text": text}
+            # API field names: name, distance (meters), time (seconds)
+            reminder_data: dict[str, Any] = {"name": text}
 
             if distance_alert is not None:
-                # Convert km to meters
-                reminder_data["distance_alert"] = int(distance_alert * 1000)
+                reminder_data["distance"] = int(distance_alert * 1000)
 
             if time_alert is not None:
-                # Convert hours to seconds
-                reminder_data["time_alert"] = time_alert * 3600
+                reminder_data["time"] = time_alert * 3600
 
             if distance_alert is None and time_alert is None:
                 return ResponseBuilder.build_error_response(
@@ -304,20 +302,26 @@ async def create_gear_reminder(
                     error_type="validation_error",
                 )
 
-            reminder = await client.create_gear_reminder(
-                gear_id, reminder_data, athlete_id=athlete_id
+            # The API returns the full Gear object; the new reminder is the
+            # newest entry carrying the name we just sent.
+            gear = await client.create_gear_reminder(gear_id, reminder_data, athlete_id=athlete_id)
+            reminder = next(
+                (
+                    r
+                    for r in sorted(gear.reminders, key=lambda r: r.id, reverse=True)
+                    if r.name == text
+                ),
+                None,
             )
 
-            result: dict[str, Any] = {
-                "id": reminder.id,
-                "gear_id": gear_id,
-                "text": reminder.text,
-            }
+            result: dict[str, Any] = {"gear_id": gear_id, "text": text}
 
-            if reminder.distance_alert is not None:
-                result["alert_every_km"] = round(reminder.distance_alert / 1000, 2)
-            if reminder.time_alert is not None:
-                result["alert_every_hours"] = reminder.time_alert // 3600
+            if reminder is not None:
+                result["id"] = reminder.id
+                if reminder.distance:
+                    result["alert_every_km"] = round(reminder.distance / 1000, 2)
+                if reminder.time:
+                    result["alert_every_hours"] = int(reminder.time // 3600)
 
             return ResponseBuilder.build_response(
                 result,
@@ -351,46 +355,39 @@ async def update_gear_reminder(
 
     try:
         async with ICUClient(config) as client:
+            # API field names: name, distance (meters), time (seconds)
             reminder_data: dict[str, Any] = {}
 
             if text is not None:
-                reminder_data["text"] = text
+                reminder_data["name"] = text
 
             if distance_alert is not None:
-                # Convert km to meters
-                reminder_data["distance_alert"] = int(distance_alert * 1000)
+                reminder_data["distance"] = int(distance_alert * 1000)
 
             if time_alert is not None:
-                # Convert hours to seconds
-                reminder_data["time_alert"] = time_alert * 3600
+                reminder_data["time"] = time_alert * 3600
 
             if not reminder_data:
                 return ResponseBuilder.build_error_response(
                     "No fields provided to update", error_type="validation_error"
                 )
 
-            reminder = await client.update_gear_reminder(
+            # The API returns the full Gear object; report the reminder we updated.
+            gear = await client.update_gear_reminder(
                 gear_id, reminder_id, reminder_data, athlete_id=athlete_id
             )
+            reminder = next((r for r in gear.reminders if r.id == reminder_id), None)
 
-            result: dict[str, Any] = {
-                "id": reminder.id,
-                "gear_id": gear_id,
-                "text": reminder.text,
-            }
+            result: dict[str, Any] = {"id": reminder_id, "gear_id": gear_id}
 
-            if reminder.distance_alert is not None:
-                result["alert_every_km"] = round(reminder.distance_alert / 1000, 2)
-            if reminder.time_alert is not None:
-                result["alert_every_hours"] = reminder.time_alert // 3600
-
-            if reminder.is_due is not None:
-                result["is_due"] = reminder.is_due
-
-            if reminder.due_distance is not None:
-                result["due_in_km"] = round(reminder.due_distance / 1000, 2)
-            if reminder.due_time is not None:
-                result["due_in_hours"] = reminder.due_time // 3600
+            if reminder is not None:
+                result["text"] = reminder.name
+                if reminder.distance:
+                    result["alert_every_km"] = round(reminder.distance / 1000, 2)
+                if reminder.time:
+                    result["alert_every_hours"] = int(reminder.time // 3600)
+                if reminder.percent_used is not None:
+                    result["percent_used"] = round(reminder.percent_used, 1)
 
             return ResponseBuilder.build_response(
                 result,

--- a/tests/test_gear_tools.py
+++ b/tests/test_gear_tools.py
@@ -43,17 +43,19 @@ class TestGetGearList:
                         "reminders": [
                             {
                                 "id": 101,
-                                "text": "Replace chain",
-                                "distance_alert": 5000000.0,  # 5000 km
-                                "due_distance": 250000.0,  # 250 km
-                                "is_due": False,
+                                "name": "Replace chain",
+                                "distance": 5000000.0,  # every 5000 km
+                                "time": 0.0,
+                                "distance_used": 4750000.0,  # 4750 km since reset
+                                "percent_used": 95.0,
                             },
                             {
                                 "id": 102,
-                                "text": "Service",
-                                "time_alert": 360000,  # 100h
-                                "due_time": 3600,  # 1h
-                                "is_due": True,
+                                "name": "Service",
+                                "distance": 0.0,
+                                "time": 360000.0,  # every 100h
+                                "time_used": 356400.0,  # 99h since reset
+                                "percent_used": 99.0,
                                 "snoozed_until": "2026-06-01",
                             },
                         ],
@@ -81,13 +83,17 @@ class TestGetGearList:
         assert bike["usage"]["activity_count"] == 142
         assert len(bike["reminders"]) == 2
         chain = bike["reminders"][0]
+        assert chain["text"] == "Replace chain"
         assert chain["alert_every_km"] == 5000.0
-        assert chain["due_in_km"] == 250.0
-        assert chain["is_due"] is False
+        assert chain["used_km"] == 4750.0
+        assert chain["percent_used"] == 95.0
         service = bike["reminders"][1]
         assert service["alert_every_hours"] == 100
-        assert service["due_in_hours"] == 1
+        assert service["used_hours"] == 99.0
         assert service["snoozed_until"] == "2026-06-01"
+        # zero thresholds (API's "unused") are omitted, not shown as 0
+        assert "alert_every_hours" not in chain
+        assert "alert_every_km" not in service
         # Minimal gear has no usage block
         assert "usage" not in gear[1]
         assert response["metadata"]["count"] == 2
@@ -241,11 +247,21 @@ class TestDeleteGear:
 
 class TestCreateGearReminder:
     async def test_success_with_distance_alert(self, patch_config, respx_mock):
-        """Distance is converted km → meters on send and back to km on response."""
-        route = respx_mock.post("/athlete/i123456/gear/g1/reminders").mock(
+        """POSTs the singular /reminder path with API field names (regression
+        for #107 — the plural path 404s and `text`/`distance_alert` 422).
+        Distance is converted km → meters on send and back to km on response;
+        the API responds with the full gear object, not the reminder."""
+        route = respx_mock.post("/athlete/i123456/gear/g1/reminder").mock(
             return_value=Response(
                 200,
-                json={"id": 200, "text": "Replace chain", "distance_alert": 5000000.0},
+                json={
+                    "id": "g1",
+                    "name": "Road Bike",
+                    "reminders": [
+                        {"id": 199, "name": "Replace chain", "distance": 1000000.0},
+                        {"id": 200, "name": "Replace chain", "distance": 5000000.0, "time": 0.0},
+                    ],
+                },
             )
         )
 
@@ -254,24 +270,30 @@ class TestCreateGearReminder:
         )
 
         sent = json.loads(route.calls[0].request.content)
-        assert sent == {"text": "Replace chain", "distance_alert": 5000000}
+        assert sent == {"name": "Replace chain", "distance": 5000000}
         response = json.loads(result)
+        # newest matching reminder (id 200) is reported, not the older duplicate
+        assert response["data"]["id"] == 200
         assert response["data"]["alert_every_km"] == 5000.0
 
     async def test_success_with_time_alert(self, patch_config, respx_mock):
         """Time is converted hours → seconds on send and back to hours on response."""
-        route = respx_mock.post("/athlete/i123456/gear/g1/reminders").mock(
+        route = respx_mock.post("/athlete/i123456/gear/g1/reminder").mock(
             return_value=Response(
                 200,
-                json={"id": 201, "text": "Service", "time_alert": 360000},
+                json={
+                    "id": "g1",
+                    "reminders": [{"id": 201, "name": "Service", "time": 360000.0}],
+                },
             )
         )
 
         result = await create_gear_reminder(gear_id="g1", text="Service", time_alert=100)
 
         sent = json.loads(route.calls[0].request.content)
-        assert sent == {"text": "Service", "time_alert": 360000}
+        assert sent == {"name": "Service", "time": 360000}
         response = json.loads(result)
+        assert response["data"]["id"] == 201
         assert response["data"]["alert_every_hours"] == 100
 
     async def test_no_alert_validation_error(self, patch_config):
@@ -284,15 +306,22 @@ class TestCreateGearReminder:
 
 class TestUpdateGearReminder:
     async def test_success_partial_update(self, patch_config, respx_mock):
-        route = respx_mock.put("/athlete/i123456/gear/g1/reminders/200").mock(
+        """PUTs the singular /reminder/{id} path; the response gear's matching
+        reminder is reported back."""
+        route = respx_mock.put("/athlete/i123456/gear/g1/reminder/200").mock(
             return_value=Response(
                 200,
                 json={
-                    "id": 200,
-                    "text": "New text",
-                    "distance_alert": 3000000.0,
-                    "due_distance": 100000.0,
-                    "is_due": True,
+                    "id": "g1",
+                    "reminders": [
+                        {"id": 199, "name": "Other", "distance": 1000000.0},
+                        {
+                            "id": 200,
+                            "name": "New text",
+                            "distance": 3000000.0,
+                            "percent_used": 42.5,
+                        },
+                    ],
                 },
             )
         )
@@ -302,13 +331,13 @@ class TestUpdateGearReminder:
         )
 
         sent = json.loads(route.calls[0].request.content)
-        assert sent == {"text": "New text", "distance_alert": 3000000}
+        assert sent == {"name": "New text", "distance": 3000000}
         response = json.loads(result)
         data = response["data"]
+        assert data["id"] == 200
         assert data["text"] == "New text"
         assert data["alert_every_km"] == 3000.0
-        assert data["due_in_km"] == 100.0
-        assert data["is_due"] is True
+        assert data["percent_used"] == 42.5
 
     async def test_no_fields_validation_error(self, patch_config):
         result = await update_gear_reminder(gear_id="g1", reminder_id=200)


### PR DESCRIPTION
## Summary

Fixes #107 — `icu_create_gear_reminder` and `icu_update_gear_reminder` never worked (HTTP 404 on every call), and reminder data in `icu_get_gear_list` was silently reduced to an id. Found via a systematic audit of every `client.py` endpoint call against `openapi-spec.json`.

## Changes

- **Paths**: `POST .../gear/{id}/reminder` and `PUT .../gear/{id}/reminder/{rid}` (singular) — the plural forms the client called do not exist (live: 404).
- **Write fields**: the tools' friendly params are unchanged (`text`, `distance_alert` km, `time_alert` h) but now map to the API's real schema: `name`, `distance` (m), `time` (s). The invented `text`/`distance_alert`/`time_alert` fields 422'd even on the correct path.
- **Model**: `GearReminder` rewritten to the real API schema (`name`, `distance`, `time`, `activities`, `days`, `percent_used`, `*_used`, `starting_*`, `last_reset`, `snoozed_until`) — previously it declared the same invented fields, so parsing a real reminder produced an id-only record.
- **Response handling**: create/update return the full **Gear** object (not the reminder); the client now types them as `Gear` and the tools extract the affected reminder — newest matching name on create, by id on update.
- **Gear list**: reminders now surface real content — text, thresholds (distance/time/activities/days), `percent_used`, `used_km`/`used_hours`, `snoozed_until`. Zero thresholds (the API's "unused") are omitted rather than shown as 0.

## Test plan

- `make can-release` passes (356 tests, ruff, pyright, packaging)
- Reminder tests rewritten against the real API shapes (singular paths, gear-object responses, field mapping both directions)
- Live-verified end-to-end through the actual tool functions: create (correct km→m round trip) → name-only update (distance threshold **preserved** — the API merges partial updates, so the tool's "only fields you pass are sent" contract holds) → gear list shows the reminder with `percent_used` → deleted via the API and confirmed gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)