### PR TITLE
fix(wellness): surface and write subjective hydration rating

### DIFF
--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -20,6 +20,7 @@ WELLNESS_SCALES: dict[str, str] = {
     "mood": "1-5 (1=very poor, 5=very good)",
     "motivation": "1-5 (1=very low, 5=very high)",
     "injury": "1-5 (1=none, 5=severe)",
+    "hydration": "1-4 (1=well hydrated, 4=very dehydrated)",
     "sleep_quality": "1-5 (1=Great, 5=Poor — inverted scale)",
     "sleep_score": "0-100 (device-specific, higher is better)",
     "readiness": "0-100 (higher is better)",
@@ -58,7 +59,7 @@ def _format_wellness_record(record: Any, date_id: str) -> dict[str, Any]:
 
     # Subjective feelings
     subjective: dict[str, Any] = {}
-    for field in ["fatigue", "soreness", "stress", "mood", "motivation", "injury"]:
+    for field in ["fatigue", "soreness", "stress", "mood", "motivation", "injury", "hydration"]:
         if getattr(record, field, None):
             subjective[field] = getattr(record, field)
     if getattr(record, "readiness", None):

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -12,7 +12,8 @@ from ..response_builder import ResponseBuilder
 # Scale labels for subjective metrics — surfaced in response metadata so LLM
 # clients that only see the JSON payload (not the tool docstring) can still
 # interpret the values correctly. Direction matters: sleep_quality is inverted
-# (1=Great, 5=Poor) while every other 1-5 metric is "higher = more".
+# (1=Great, 5=Poor) while every other 1-5 metric is "higher = more"; hydration
+# uses a 1-4 range in the same higher-is-worse direction.
 WELLNESS_SCALES: dict[str, str] = {
     "fatigue": "1-5 (1=very low, 5=very high)",
     "soreness": "1-5 (1=very low, 5=very high)",
@@ -356,6 +357,9 @@ async def update_wellness(
     mood: Annotated[int | None, "Mood level (1-5 scale)"] = None,
     motivation: Annotated[int | None, "Motivation level (1-5 scale)"] = None,
     injury: Annotated[int | None, "Injury severity (1-5 scale: 1=none, 5=severe)"] = None,
+    hydration: Annotated[
+        int | None, "Subjective hydration rating (1-4: 1=well hydrated, 4=very dehydrated)"
+    ] = None,
     readiness: Annotated[float | None, "Readiness score (0-100)"] = None,
     body_fat: Annotated[float | None, "Body fat percentage"] = None,
     abdomen: Annotated[float | None, "Abdominal circumference in cm"] = None,
@@ -426,6 +430,8 @@ async def update_wellness(
             wellness_data["motivation"] = motivation
         if injury is not None:
             wellness_data["injury"] = injury
+        if hydration is not None:
+            wellness_data["hydration"] = hydration
         if readiness is not None:
             wellness_data["readiness"] = readiness
         if body_fat is not None:

--- a/tests/test_wellness_tools.py
+++ b/tests/test_wellness_tools.py
@@ -178,7 +178,29 @@ class TestWellnessTools:
         assert data["nutrition"]["hydration_liters"] == 2.5
         scales = response["metadata"]["scales"]
         assert "hydration" in scales and "1-4" in scales["hydration"]
-        assert "stress" not in scales
+
+    async def test_update_wellness_writes_hydration_rating(self, mock_config, respx_mock):
+        """The subjective rating is writable and distinct from hydrationVolume."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.put("/athlete/i123456/wellness").mock(
+            return_value=Response(
+                200,
+                json={"id": "2026-04-22", "hydration": 3, "hydrationVolume": 1.5},
+            )
+        )
+
+        result = await update_wellness(
+            date="2026-04-22", hydration=3, hydration_liters=1.5, ctx=mock_ctx
+        )
+
+        sent = json.loads(route.calls[0].request.content)
+        assert sent["hydration"] == 3
+        assert sent["hydrationVolume"] == 1.5
+        response = json.loads(result)
+        assert response["data"]["subjective"]["hydration"] == 3
+        assert response["data"]["nutrition"]["hydration_liters"] == 1.5
 
     async def test_get_wellness_data_includes_scales_and_extra_fields(
         self, mock_config, respx_mock

--- a/tests/test_wellness_tools.py
+++ b/tests/test_wellness_tools.py
@@ -150,6 +150,34 @@ class TestWellnessTools:
         assert "readiness" in scales and "0-100" in scales["readiness"]
         # Scales for fields not present should be absent
         assert "soreness" not in scales
+
+    async def test_get_wellness_for_date_surfaces_hydration_rating(self, mock_config, respx_mock):
+        """The subjective 1-4 hydration rating was silently dropped by the
+        formatter (it is enumerated on the model, so it never reached the
+        custom_fields fallback either). It must surface with its scale."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/athlete/i123456/wellness/2026-04-21").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "2026-04-21",
+                    "hydration": 2,
+                    "hydrationVolume": 2.5,
+                },
+            )
+        )
+
+        result = await get_wellness_for_date(date="2026-04-21", ctx=mock_ctx)
+        response = json.loads(result)
+
+        data = response["data"]
+        assert data["subjective"]["hydration"] == 2
+        # the liters-drunk volume stays a separate nutrition field
+        assert data["nutrition"]["hydration_liters"] == 2.5
+        scales = response["metadata"]["scales"]
+        assert "hydration" in scales and "1-4" in scales["hydration"]
         assert "stress" not in scales
 
     async def test_get_wellness_data_includes_scales_and_extra_fields(


### PR DESCRIPTION
## Summary

The wellness formatter silently dropped the subjective `hydration` rating — the same bug class as the custom-fields drop fixed in #98, one layer deeper: because `hydration` **is** enumerated on the `Wellness` model, it never reached the `custom_fields` fallback either. An athlete logging hydration on the wellness page got no trace of it in MCP responses.

## Changes

- `hydration` now surfaces in the `subjective` block, alongside fatigue/soreness/etc.
- Added the scale to `WELLNESS_SCALES`: `1-4 (1=well hydrated, 4=very dehydrated)` — range live-verified (the API accepts exactly 1–4; 0 and 5+ return HTTP 422), direction per the feature's forum thread ("Well Hydrated → Very Dehydrated" levels).
- The liters-drunk `hydrationVolume` is unaffected and stays a separate `nutrition.hydration_liters` field.

## Test plan

- `make can-release` passes (357 tests, ruff, pyright, packaging)
- New regression test: hydration surfaces under `subjective` with its scale in metadata, volume stays in `nutrition`
- Live-verified through the actual tool: wrote `hydration: 2` to an empty past date → response shows `subjective.hydration = 2` plus the scale; probe data cleared afterward (fun fact discovered during cleanup: the API ignores `null` on standard wellness fields — `-1` is the clear marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)