### PR TITLE
Fix activity RPE mapping for icu_rpe responses

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -169,7 +169,10 @@ class Activity(ActivitySummary):
     hrss: float | None = None
     trimp: float | None = None
     feel: int | None = None
-    perceived_exertion: int | None = None
+    perceived_exertion: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("perceived_exertion", "icu_rpe"),
+    )
     compliance: float | None = None
     avg_lr_balance: float | None = None
     commute: bool | None = None

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -203,6 +203,31 @@ class TestActivityTools:
         assert response["data"]["subjective"] == {"feel": 4, "rpe": 7}
         assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
 
+    async def test_get_activity_details_maps_icu_rpe(self, mock_config, respx_mock):
+        """The native icu_rpe response field is exposed as subjective RPE."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "feel": 3,
+                    "icu_rpe": 3,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"feel": 3, "rpe": 3}
+        assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
+
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""
         mock_ctx = MagicMock()


### PR DESCRIPTION
## What changed

- Accept the native Intervals.icu `icu_rpe` activity response field as an alias for `perceived_exertion`.
- Preserve compatibility with API responses that already use `perceived_exertion`.
- Add a regression test confirming that `icu_get_activity_details` exposes `icu_rpe` as `subjective.rpe` with the correct 1–10 scale metadata.

## Why

Intervals.icu activity detail responses can store the athlete-entered RPE in `icu_rpe`. The activity model only read `perceived_exertion`, so a valid RPE was silently dropped while `feel` continued to work.

## Impact

Clients using `icu_get_activity_details` can reliably read athlete-entered RPE and distinguish it from the separate Feeling metric.

## Validation

- `uv run pytest -q` — 364 passed
- `uv run ruff check src tests` — passed
- `uv run pyright` — 0 errors
- `git diff --check` — passed
