### PR TITLE
Expose heart-rate and power zones in sport settings

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -40,9 +40,28 @@ class SportSettings(BaseModel):
 
     id: int
     type: str | None = None
+
+    # Default workout timings
+    warmup_time: int | None = None
+    cooldown_time: int | None = None
+
+    # Power settings
     ftp: int | None = None
     indoor_ftp: int | None = None
+    power_zones: list[int] | None = None
+    power_zone_names: list[str] | None = None
+    sweet_spot_min: int | None = None
+    sweet_spot_max: int | None = None
+
+    # Heart-rate settings
     fthr: int | None = None
+    max_hr: int | None = None
+    hr_zones: list[int] | None = None
+    hr_zone_names: list[str] | None = None
+    hr_load_type: str | None = None
+    hrrc_min_percent: float | None = None
+
+    # Pace / swimming settings
     pace_threshold: float | None = None
     swim_threshold: float | None = None
 
@@ -55,6 +74,7 @@ class SportSettings(BaseModel):
 
         raw = cast(dict[str, Any], data)
         normalized: dict[str, Any] = dict(raw)
+
         types = raw.get("types")
         if isinstance(types, list) and types and normalized.get("type") is None:
             normalized["type"] = types[0]
@@ -66,16 +86,20 @@ class SportSettings(BaseModel):
         if threshold_pace is not None:
             pace_load_type = raw.get("pace_load_type")
             sport_types = cast(list[Any], types) if isinstance(types, list) else []
+
             is_swim = pace_load_type == "SWIM" or any(
-                isinstance(t, str) and t in _SWIM_SPORT_TYPES for t in sport_types
+                isinstance(t, str) and t in _SWIM_SPORT_TYPES
+                for t in sport_types
             )
-            # The API stores RUN pace as min/km (5:45/km -> 5.75) but SWIM pace as
-            # SPEED in m/s (0:25/100m -> 4.0). Convert swim m/s -> min/100m; use the
-            # run pace directly. (Sending swim as min/100m stored a bogus speed, #88.)
+
+            # The API stores RUN pace as min/km but SWIM threshold
+            # as speed in m/s. Convert swimming speed to min/100m.
             if is_swim:
                 if normalized.get("swim_threshold") is None:
                     normalized["swim_threshold"] = (
-                        (100.0 / threshold_pace) / 60.0 if threshold_pace else None
+                        (100.0 / threshold_pace) / 60.0
+                        if threshold_pace
+                        else None
                     )
             elif normalized.get("pace_threshold") is None:
                 normalized["pace_threshold"] = threshold_pace

--- a/src/intervals_icu_mcp/sport_settings_format.py
+++ b/src/intervals_icu_mcp/sport_settings_format.py
@@ -5,6 +5,34 @@ from typing import Any
 from .models import SportSettings
 
 
+def _format_zones(
+    limits: list[int],
+    names: list[str] | None = None,
+    *,
+    min_value: int = 0,
+    min_key: str,
+    max_key: str,
+) -> list[dict[str, Any]]:
+    """Convert Intervals.icu upper zone limits into explicit zone ranges."""
+    zones: list[dict[str, Any]] = []
+    current_min = min_value
+
+    for index, max_value in enumerate(limits, start=1):
+        zone: dict[str, Any] = {
+            "zone": f"Z{index}",
+            min_key: current_min,
+            max_key: max_value,
+        }
+
+        if names and index <= len(names):
+            zone["name"] = names[index - 1]
+
+        zones.append(zone)
+        current_min = max_value + 1
+
+    return zones
+
+
 def format_sport_settings_entry(
     settings: SportSettings,
     *,
@@ -12,23 +40,80 @@ def format_sport_settings_entry(
 ) -> dict[str, Any]:
     """Build an LLM-facing sport settings dict with consistent unit suffixes."""
     sport_info: dict[str, Any] = {}
+
     if include_id:
         sport_info["id"] = settings.id
+
     if settings.type is not None:
         sport_info["type"] = settings.type
+
+    # Default workout timings
+    if settings.warmup_time is not None:
+        sport_info["warmup_seconds"] = settings.warmup_time
+
+    if settings.cooldown_time is not None:
+        sport_info["cooldown_seconds"] = settings.cooldown_time
+
+    # Power
     if settings.ftp is not None:
         sport_info["ftp_watts"] = settings.ftp
+
     if settings.indoor_ftp is not None:
         sport_info["indoor_ftp_watts"] = settings.indoor_ftp
+
+    if settings.power_zones is not None:
+        sport_info["power_zones_percent_ftp"] = _format_zones(
+            settings.power_zones,
+            settings.power_zone_names,
+            min_value=0,
+            min_key="min_percent_ftp",
+            max_key="max_percent_ftp",
+        )
+
+    if settings.sweet_spot_min is not None:
+        sport_info["sweet_spot_min_percent_ftp"] = settings.sweet_spot_min
+
+    if settings.sweet_spot_max is not None:
+        sport_info["sweet_spot_max_percent_ftp"] = settings.sweet_spot_max
+
+    # Heart rate
     if settings.fthr is not None:
         sport_info["fthr_bpm"] = settings.fthr
+
+    if settings.max_hr is not None:
+        sport_info["max_hr_bpm"] = settings.max_hr
+
+    if settings.hr_zones is not None:
+        sport_info["hr_zones"] = _format_zones(
+            settings.hr_zones,
+            settings.hr_zone_names,
+            min_value=0,
+            min_key="min_bpm",
+            max_key="max_bpm",
+        )
+
+    if settings.hr_load_type is not None:
+        sport_info["hr_load_type"] = settings.hr_load_type
+
+    if settings.hrrc_min_percent is not None:
+        sport_info["hrrc_min_percent"] = settings.hrrc_min_percent
+
+    # Running pace
     if settings.pace_threshold is not None:
         total = round(settings.pace_threshold * 60)
-        sport_info["pace_threshold"] = f"{total // 60}:{total % 60:02d} /km"
+        sport_info["pace_threshold"] = (
+            f"{total // 60}:{total % 60:02d} /km"
+        )
+
+    # Swimming pace
     if settings.swim_threshold is not None:
-        # round, not truncate — the m/s <-> min/100m conversion adds tiny float error
+        # round, not truncate — the m/s <-> min/100m conversion
+        # adds tiny floating-point error
         total = round(settings.swim_threshold * 60)
-        sport_info["swim_threshold"] = f"{total // 60}:{total % 60:02d} /100m"
+        sport_info["swim_threshold"] = (
+            f"{total // 60}:{total % 60:02d} /100m"
+        )
+
     return sport_info
 
 
@@ -50,24 +135,34 @@ def build_sport_settings_api_payload(
         )
 
     payload: dict[str, Any] = {}
+
     if sport_type is not None:
         payload["types"] = [sport_type]
+
     if ftp is not None:
         payload["ftp"] = ftp
+
     if indoor_ftp is not None:
         payload["indoor_ftp"] = indoor_ftp
+
     if fthr is not None:
         payload["lthr"] = fthr
+
     if pace_threshold is not None:
         payload["threshold_pace"] = pace_threshold
         payload["pace_units"] = "MINS_KM"
         payload["pace_load_type"] = "RUN"
+
     if swim_threshold is not None:
-        # Intervals.icu stores swim threshold as SPEED in m/s (unlike run, which is
-        # min/km). Convert min/100m -> m/s: 100 m / (minutes * 60) s. Sending the
-        # pace value directly stored a bogus speed (4.0 -> 4 m/s -> 0:25/100m); the
-        # old `* 60` sent seconds the API rejects with HTTP 422 (see #88).
-        payload["threshold_pace"] = 100.0 / (swim_threshold * 60) if swim_threshold else 0.0
+        # Intervals.icu stores swim threshold as SPEED in m/s.
+        # Convert min/100m -> m/s:
+        # 100 m / (minutes * 60 seconds)
+        payload["threshold_pace"] = (
+            100.0 / (swim_threshold * 60)
+            if swim_threshold
+            else 0.0
+        )
         payload["pace_units"] = "SECS_100M"
         payload["pace_load_type"] = "SWIM"
+
     return payload


### PR DESCRIPTION
## Changes

- Expose max heart rate from Intervals.icu sport settings
- Expose HR zones and HR zone names
- Expose HR load type and HRRc minimum percentage
- Expose power zones and power zone names
- Expose sweet spot limits
- Expose default warmup/cooldown durations
- Format zone upper limits as explicit min/max ranges for LLM consumers

## Motivation

Intervals.icu API already returns these fields, but the MCP SportSettings
Pydantic model discarded them before formatting the MCP response.

This caused icu_get_sport_settings to expose only FTP/FTHR even though
the athlete had configured HR and power zones in Intervals.icu.