### PR TITLE
fix(activities): round-trip RPE through the native icu_rpe field

### DIFF
--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -169,9 +169,13 @@ class Activity(ActivitySummary):
     hrss: float | None = None
     trimp: float | None = None
     feel: int | None = None
+    # Intervals.icu stores the athlete-entered RPE in `icu_rpe` (int 1-10).
+    # `perceived_exertion` is the Strava-imported mirror of the same rating and
+    # is a float in the API spec, so it is only read as a fallback — otherwise a
+    # fractional import would shadow the native value.
     perceived_exertion: int | None = Field(
         default=None,
-        validation_alias=AliasChoices("perceived_exertion", "icu_rpe"),
+        validation_alias=AliasChoices("icu_rpe", "perceived_exertion"),
     )
     compliance: float | None = None
     avg_lr_balance: float | None = None

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -173,7 +173,9 @@ class Activity(ActivitySummary):
     # Intervals.icu stores the athlete-entered RPE in `icu_rpe` (int 1-10).
     # `perceived_exertion` is the Strava-imported mirror of the same rating and
     # is a float in the API spec, so it is only read as a fallback — otherwise a
-    # fractional import would shadow the native value.
+    # fractional import would shadow the native value. `_resolve_rpe` below does
+    # the actual falling back; the alias order only covers a response that omits
+    # `icu_rpe` entirely.
     perceived_exertion: int | None = Field(
         default=None,
         validation_alias=AliasChoices("icu_rpe", "perceived_exertion"),
@@ -184,6 +186,25 @@ class Activity(ActivitySummary):
     trainer: bool | None = None
     indoor: bool | None = None
     analyzed: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_rpe(cls, data: Any) -> Any:
+        """Fall back to the Strava-imported RPE when the native one is null.
+
+        The API always sends `icu_rpe`, explicitly null when the athlete has not
+        entered an RPE, and `AliasChoices` resolves on key presence rather than
+        null-ness — so on its own the fallback would never fire in production.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        raw = cast(dict[str, Any], data)
+        if raw.get("icu_rpe") is None and raw.get("perceived_exertion") is not None:
+            resolved: dict[str, Any] = dict(raw)
+            resolved["icu_rpe"] = resolved["perceived_exertion"]
+            return resolved
+        return raw
 
     @field_validator("perceived_exertion", mode="before")
     @classmethod

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -1,5 +1,6 @@
 """Pydantic models for Intervals.icu API responses."""
 
+import math
 from datetime import datetime
 from typing import Any, Literal, cast
 
@@ -183,6 +184,15 @@ class Activity(ActivitySummary):
     trainer: bool | None = None
     indoor: bool | None = None
     analyzed: str | None = None
+
+    @field_validator("perceived_exertion", mode="before")
+    @classmethod
+    def _round_perceived_exertion(cls, v: Any) -> Any:
+        """RPE is a whole number on the 1-10 scale, but `perceived_exertion` is
+        typed float by the API. Round rather than fail the whole activity."""
+        if isinstance(v, float):
+            return math.floor(v + 0.5) if math.isfinite(v) else None
+        return v
 
 
 class ActivitySearchResult(BaseModel):

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -169,7 +169,10 @@ class Activity(ActivitySummary):
     hrss: float | None = None
     trimp: float | None = None
     feel: int | None = None
-    perceived_exertion: int | None = None
+    perceived_exertion: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("perceived_exertion", "icu_rpe"),
+    )
     compliance: float | None = None
     avg_lr_balance: float | None = None
     commute: bool | None = None

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -406,7 +406,10 @@ async def update_activity(
         if feel is not None:
             activity_data["feel"] = feel
         if perceived_exertion is not None:
-            activity_data["perceived_exertion"] = perceived_exertion
+            # `icu_rpe` is the field Intervals.icu actually stores the athlete's
+            # RPE in; `perceived_exertion` is the Strava-imported mirror, so
+            # writing that key left the RPE shown in the UI unchanged.
+            activity_data["icu_rpe"] = perceived_exertion
 
         if not activity_data:
             return ResponseBuilder.build_error_response(

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -291,6 +291,32 @@ class TestActivityTools:
 
         assert response["data"]["subjective"] == {"rpe": 7}
 
+    async def test_get_activity_details_fractional_perceived_exertion(
+        self, mock_config, respx_mock
+    ):
+        """A fractional `perceived_exertion` (typed float by the API) is rounded
+        onto the 1-10 scale instead of failing validation for the whole activity."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "perceived_exertion": 6.5,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"rpe": 7}
+
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""
         mock_ctx = MagicMock()

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -47,6 +47,42 @@ class TestActivityTools:
         assert response["data"]["name"] == "Updated Ride"
         assert response["metadata"]["message"] == "Successfully updated activity a123"
 
+    async def test_update_activity_writes_icu_rpe(self, mock_config, respx_mock):
+        """RPE is written to the API's native `icu_rpe` field, not to the
+        read-only `perceived_exertion` mirror, so it round-trips."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        route = respx_mock.put("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Updated Ride",
+                    "type": "Ride",
+                    "feel": 4,
+                    "icu_rpe": 7,
+                },
+            )
+        )
+
+        result = await update_activity(
+            activity_id="a123",
+            feel=4,
+            perceived_exertion=7,
+            ctx=mock_ctx,
+        )
+
+        sent = json.loads(route.calls[0].request.content)
+        assert sent["icu_rpe"] == 7
+        assert sent["feel"] == 4
+        assert "perceived_exertion" not in sent
+
+        response = json.loads(result)
+        assert response["data"]["rpe"] == 7
+        assert response["data"]["feel"] == 4
+
     async def test_update_activity_not_found(self, mock_config, respx_mock):
         """Test updating a non-existent activity."""
         mock_ctx = MagicMock()
@@ -227,6 +263,33 @@ class TestActivityTools:
 
         assert response["data"]["subjective"] == {"feel": 3, "rpe": 3}
         assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
+
+    async def test_get_activity_details_icu_rpe_wins_over_perceived_exertion(
+        self, mock_config, respx_mock
+    ):
+        """`icu_rpe` is the athlete-entered value and takes precedence over the
+        Strava-imported `perceived_exertion` float."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "icu_rpe": 7,
+                    "perceived_exertion": 6.5,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"rpe": 7}
 
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -203,6 +203,31 @@ class TestActivityTools:
         assert response["data"]["subjective"] == {"feel": 4, "rpe": 7}
         assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
 
+    async def test_get_activity_details_maps_icu_rpe(self, mock_config, respx_mock):
+        """The native icu_rpe response field is exposed as subjective RPE."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "feel": 3,
+                    "icu_rpe": 3,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"feel": 3, "rpe": 3}
+        assert response["metadata"]["subjective_scales"] == {"feel": "1-5", "rpe": "1-10"}
+
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""
         mock_ctx = MagicMock()

--- a/tests/test_activity_tools.py
+++ b/tests/test_activity_tools.py
@@ -317,6 +317,59 @@ class TestActivityTools:
 
         assert response["data"]["subjective"] == {"rpe": 7}
 
+    async def test_get_activity_details_null_icu_rpe_falls_back(self, mock_config, respx_mock):
+        """The API always sends `icu_rpe`, explicitly null when the athlete has
+        not entered an RPE — so an imported `perceived_exertion` must still be
+        read. AliasChoices resolves on key presence, hence the model validator."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "icu_rpe": None,
+                    "perceived_exertion": 6.5,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert response["data"]["subjective"] == {"rpe": 7}
+        assert response["metadata"]["subjective_scales"] == {"rpe": "1-10"}
+
+    async def test_get_activity_details_both_rpe_fields_null(self, mock_config, respx_mock):
+        """Both RPE fields null — the shape of most real activities — reports no
+        RPE rather than inventing one."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
+
+        respx_mock.get("/activity/a123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "id": "a123",
+                    "start_date_local": "2026-03-20T10:00:00",
+                    "name": "Test Ride",
+                    "type": "Ride",
+                    "icu_rpe": None,
+                    "perceived_exertion": None,
+                },
+            )
+        )
+
+        result = await get_activity_details(activity_id="a123", ctx=mock_ctx)
+        response = json.loads(result)
+
+        assert "subjective" not in response["data"]
+        assert "subjective_scales" not in response.get("metadata", {})
+
     async def test_get_activity_details_partial_nutrition(self, mock_config, respx_mock):
         """Nutrition section omits null fields; preserves zero values."""
         mock_ctx = MagicMock()


### PR DESCRIPTION
## Summary

Completes #114 with the write-path change you asked for in review. RPE now round-trips: it is read from and written to `icu_rpe`, the field Intervals.icu actually stores the athlete-entered rating in.

**Credit:** the first commit on this branch is @AlexVrg71's original work from #114 — I picked up the review follow-ups after offering on that thread. Happy to close this in favour of #114 if @AlexVrg71 would rather push the same changes there; this is just the work already done.

## Changes

- **Write path** — `icu_update_activity` sent `perceived_exertion`, the Strava-imported mirror of the rating, so an RPE written through the tool never reached the value shown in the Intervals.icu UI. It now sends `icu_rpe`, matching the read path. Same shape as #111: align to the real API field names on both read and write.
- **Tool interface unchanged** — the `perceived_exertion` parameter keeps its name, type, and description. Only the key that goes into `activity_data` changed; no second RPE parameter.
- **`AliasChoices` order flipped** to `("icu_rpe", "perceived_exertion")` — per `openapi-spec.json`, `Activity.icu_rpe` is `int32` while `Activity.perceived_exertion` is `float`, so the native int now wins over an imported fractional value (@AlexVrg71's commit had these the other way round).
- **Fractional `perceived_exertion` no longer fails the whole activity** *(separate commit, `fix(models): tolerate a fractional perceived_exertion` — easy to drop if you'd rather not take it)*. Flipping the alias order fixes precedence, but an activity carrying a fractional `perceived_exertion` and **no** `icu_rpe` still raised on `int | None`, failing the entire `Activity` model — `icu_get_activity_details` returned `Unexpected error: 1 validation error…` instead of the activity. A `mode="before"` validator now rounds onto the whole-number 1-10 scale.

## Checklist

- [x] `make can-release` passes locally (tests, ruff, pyright)
- [x] New tools have a corresponding respx-mocked test file in `tests/`
- [x] Public-facing behavior changes are reflected in the README or `docs/`
- [x] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [x] No API keys, athlete IDs, or other credentials are committed

No new tools, and no README/`docs/` change needed — `docs/tools.md` describes `icu_update_activity` generically and neither it nor the README documents the RPE field name.

## Test plan

Four cases in `tests/test_activity_tools.py`, using the `route.calls[0].request.content` payload assertion from #109:

- `test_update_activity_writes_icu_rpe` — the PUT body contains `icu_rpe: 7` and **not** `perceived_exertion`, and the response echoes `rpe: 7`
- `test_get_activity_details_icu_rpe_wins_over_perceived_exertion` — `icu_rpe: 7` alongside `perceived_exertion: 6.5` reads as `7`
- `test_get_activity_details_fractional_perceived_exertion` — a lone `perceived_exertion: 6.5` reads as `7` rather than raising
- @AlexVrg71's original `test_get_activity_details_maps_icu_rpe`, plus the pre-existing `perceived_exertion`-only test, which still passes and pins the fallback

```
367 passed · ruff clean · pyright 0 errors · coverage 85.75%
```

One caveat worth flagging: **the write path is verified against respx mocks, not the live API.** `PUT /activity/{id}` takes the full `Activity` schema, which contains both keys, so the spec alone can't prove which one the server honours — the `icu_` prefix convention and the read-side behaviour are the evidence. If you want a live confirmation before merging, I can run a set-then-restore round trip against one of my own activities and post the result.

## Not in scope

The same activity schema carries `session_rpe` (`int32`, the S-RPE the web UI shows next to RPE), which no tool surfaces today. Left alone here — happy to open a separate issue if it's wanted.
