### PR TITLE
ci: bump twine to 7.0.0 to accept metadata 2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint/pyright: ## Run pyright type checker
 lint/package: ## Validate PyPI package metadata and README rendering (twine + pyroma)
 	rm -rf dist/
 	uv build
-	uvx twine==6.2.0 check --strict dist/*
+	uvx twine==7.0.0 check --strict dist/*
 	uvx pyroma==5.0.1 --min=10 .
 
 fmt: format


### PR DESCRIPTION
`make lint/package` fails on every branch, blocking all PRs:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Current hatchling emits `Metadata-Version: 2.5`; the pinned `twine==6.2.0` predates it and rejects the wheel. Nothing to do with any PR's content — it fails identically on `main`.

twine 7.0.0 accepts it. Verified locally on both artifacts:

```
dist/intervals_icu_mcp-...-py3-none-any.whl: PASSED
dist/intervals_icu_mcp-....tar.gz:           PASSED
pyroma: 10/10
```

One line in the Makefile. Merging this unblocks #118 and #120, which are otherwise green.