### PR TITLE
docs(skills): tighten release-write length and title rules

### DIFF
--- a/.claude/skills/release-write/SKILL.md
+++ b/.claude/skills/release-write/SKILL.md
@@ -54,7 +54,7 @@ Adopt these conventions:
 
 - **Title has a tagline:** `vX.Y.Z – Headline Theme One & Headline Theme Two` (not plain `vX.Y.Z`). Same theme(s) you'd put in a tweet.
 - **Body uses narrative section headers**, not CHANGELOG-style category buckets. Examples from past releases: `## New features`, `## Improvements`, `## Notes`, or headline-named sections like `## Delete Safety Mode`. **DO NOT use `### Added / ### Fixed / ### Changed`** — that's CHANGELOG style; the release notes are different.
-- **Body is shorter than the CHANGELOG section.** Aim for ~50-70% of the CHANGELOG content, focused on what's user-visible and headline-worthy.
+- **Body fits a hard word budget** (see step 3). Never size the notes as a percentage of the CHANGELOG — a long CHANGELOG is exactly when the notes must stay short.
 - **Top callout (`> [!NOTE]`) only when there's a measured headline number** — token savings, accuracy gain, perf improvement. Skip for routine releases.
 - **Inline upgrade prose** for breaking changes — one or two sentences, no diff blocks. Pattern from v2.0.0: *"Upgrading from 1.x: \<thing> no longer \<behavior>. Set \<env var> to restore."* For multiple breaking changes, a `## Upgrading from vX.Y` heading with prose paragraphs (NOT diff snippets unless the consumer audience is parsing-heavy — see below).
 - **Single Full-Changelog comparison link at the bottom**, single line:
@@ -79,11 +79,50 @@ Don't:
 - Add emojis unless the user explicitly asks for them (per project convention).
 - Include co-author lines or AI attribution (per [feedback_commits.md] memory).
 
-### 3. Show the polished notes to the user for review
+### 3. Cut it down — mandatory, not optional
 
-Print the contents of the temp file. The user may want to tweak before publishing. Wait for explicit go-ahead before step 4.
+Nobody reads long release notes. The first draft is always too long, because every fact
+feels load-bearing while you're holding the whole diff in your head. It isn't: the CHANGELOG
+is one click away and holds the evidence. **Run this pass every time, even when the draft
+already feels tight.**
 
-### 4. Cut the release (only after user confirms)
+**Word budget** (body only, excluding the Full Changelog line) — measure it, don't estimate:
+
+```bash
+wc -w < /tmp/release-notes-X.Y.Z.md
+```
+
+| Release | Target | Hard ceiling |
+|---|---|---|
+| Patch (X.Y.**Z**) | ≤ 120 | 150 |
+| Minor (X.**Y**.0) | ≤ 250 | 300 |
+| Major (**X**.0.0, incl. upgrade section) | ≤ 350 | 400 |
+
+Historical anchors: v2.0.0 = 192 words, v3.0.0 = 415, v4.0.0 = 182. A major that lands at
+800 has failed this step. Per section: **one theme, ≤ 80 words**. More than four `##` sections
+means you're listing, not curating — merge or drop.
+
+**Over budget? Cut in this order** (each of these is CHANGELOG material, not release-notes material):
+
+1. **Second and third supporting measurements.** One number per section earns its place; the rest prove a case nobody is disputing while reading a release page.
+2. **Causal mechanism explained twice.** State the effect on the user, not the code path that produced it. "The model never declared the fields" is enough; the ordering of validation and response-building is not.
+3. **Provenance and design justification** — why the semantics were established a certain way, which bug class it resembles, what was deliberately *not* changed and why.
+4. **Sentences whose subject is the repo** rather than the user's data or tools ("This release drains…", "the list is now empty"). At most one, at the end.
+5. **Adjacent-fact "worth knowing" notes.** True, interesting, and the reason a reader stops reading.
+
+**Keep, always:** what broke, what it means for the reader's own data, the exact tool/field names to change, and the contributor credits.
+
+Then re-read the trimmed draft and ask: *does it still say the same thing?* If a cut lost
+information a user actually needs to act, restore that sentence — and take the words back
+out somewhere else, not from the budget.
+
+### 4. Show the polished notes to the user for review
+
+Print the contents of the temp file **and its word count against the budget** (e.g. "312 words,
+major budget 350"). The user may want to tweak before publishing. Wait for explicit go-ahead
+before step 5.
+
+### 5. Cut the release (only after user confirms)
 
 ```bash
 # Create the tag (no automation; just a marker)
@@ -99,7 +138,7 @@ Do NOT use `--generate-notes` — that uses GitHub's auto-generated PR/commit li
 
 Do NOT use `--draft`. The release needs to be published to trigger `publish.yml`.
 
-### 5. Verify the release published correctly
+### 6. Verify the release published correctly
 
 ```bash
 gh release view vX.Y.Z --json url,tagName,publishedAt
@@ -124,12 +163,14 @@ If it fails, surface the failure (`gh run view <id> --log-failed`) and stop — 
 - **Don't auto-publish without showing the user the polished notes.** Even if the CHANGELOG looks fine, the polish step (TL;DR, PR list, migration guide) is judgment-based and the user should approve.
 - **Don't use `--draft` then forget to publish.** `publish.yml` only fires on `release.types: [published]`, not on draft creation.
 - **Don't generate "what's changed" via `--generate-notes` for a polished release.** That's GitHub's auto-listing; it's noisier and less narrative than the CHANGELOG section.
+- **Don't skip step 3 because the draft "reads well".** Well-written and too long are the same failure here — the draft always reads well to the person who just wrote it. Measure the word count; if it's over budget, cut.
+- **Don't let a big release justify a long body.** The reverse is true: the more that changed, the more selection the reader needs from you. A major with three themes gets three sections, not eight.
 
 ## Quality bar
 
 The release body should answer three questions for a reader scanning the Releases tab:
-1. **What changed at a glance?** — the TL;DR callout.
-2. **What do I need to know to upgrade?** — the Changed (breaking) bullets + Migration section.
+1. **What changed at a glance?** — the callout, or the first section header.
+2. **What do I need to know to upgrade?** — the tool and field names to change, as prose or a short list.
 3. **Where did this come from?** — the Full Changelog comparison link.
 
-If a reader can answer those without clicking into the CHANGELOG, the polish is sufficient. Avoid duplicating the CHANGELOG into a verbose PR list at the bottom — the comparison link is enough.
+If a reader can answer those without clicking into the CHANGELOG, the polish is sufficient — and anything beyond those three answers is a candidate for the cut pass. Avoid duplicating the CHANGELOG into a verbose PR list at the bottom; the comparison link is enough.

--- a/.claude/skills/release-write/SKILL.md
+++ b/.claude/skills/release-write/SKILL.md
@@ -52,7 +52,11 @@ gh release view vPREVIOUS --json body --jq .body
 
 Adopt these conventions:
 
-- **Title has a tagline:** `vX.Y.Z – Headline Theme One & Headline Theme Two` (not plain `vX.Y.Z`). Same theme(s) you'd put in a tweet.
+- **Title has a tagline:** `vX.Y.Z – Headline Theme` (not plain `vX.Y.Z`). Same theme you'd put in a tweet.
+  - **Default to one theme.** A second (`Theme One & Theme Two`) is allowed only when both are independently headline-worthy — the shape of v2.0.0 and v4.4.0. Don't reach for a second half to fill out the line; the best titles here are the single-theme ones (v4.3.2, v1.2.0). Aim for ≤ 45 chars including the `vX.Y.Z – ` prefix.
+  - **Name the user's benefit, in the user's vocabulary.** No repo-internal process terms — "deferred cleanups", "the drained list", milestone or issue-tracker names. A reader on the Releases tab has no referent for them, and they describe maintainer bookkeeping rather than anything the reader's data now does differently. If a phrase would only parse to someone who has read CLAUDE.md, it fails.
+  - **Breaking changes are not a headline theme.** Upgrade cost belongs in the `## Upgrading from vX.Y` section, not the title — even on a major.
+  - Keep the shape flat: a noun phrase, optionally two joined by `&`. No trailing appositives or comma clauses (`… & The Deferred Cleanups, Drained` is the failure case).
 - **Body uses narrative section headers**, not CHANGELOG-style category buckets. Examples from past releases: `## New features`, `## Improvements`, `## Notes`, or headline-named sections like `## Delete Safety Mode`. **DO NOT use `### Added / ### Fixed / ### Changed`** — that's CHANGELOG style; the release notes are different.
 - **Body fits a hard word budget** (see step 3). Never size the notes as a percentage of the CHANGELOG — a long CHANGELOG is exactly when the notes must stay short.
 - **Top callout (`> [!NOTE]`) only when there's a measured headline number** — token savings, accuracy gain, perf improvement. Skip for routine releases.


### PR DESCRIPTION
## Summary

The v5.0.0 release notes ran to 830 words — against 182 for v4.0.0 and 415 for v3.0.0. The skill's length rule was the cause: it sized the body as "~50-70% of the CHANGELOG content", so a 1,396-word CHANGELOG section licensed a body four times longer than any previous major. That rule scales the wrong way — a big release is exactly when the reader needs more selection, not more text.

Two changes to `release-write`, plus the v5.0.0 body has been re-cut to 351 words on the live release.

## Changes

- **Absolute word budget replaces the CHANGELOG-relative one** — patch ≤ 120, minor ≤ 250, major ≤ 350, with hard ceilings and the historical anchors (v2.0.0 = 192, v3.0.0 = 415, v4.0.0 = 182) so drift is visible. Measured with `wc -w`, not estimated.
- **New mandatory step 3, a cut pass** with a ranked deletion order rather than "be concise": supporting measurements beyond the first, mechanism explained twice, provenance and design justification, sentences whose subject is the repo, and "worth knowing" asides — all CHANGELOG material. Paired with an explicit keep-list (what broke, what it means for the reader's data, exact tool/field names, contributor credits) and a final re-read to confirm the trimmed draft still says the same thing.
- Step 4 now prints the word count against budget when showing the draft for review, so the number is visible before publishing.
- **Title rule defaults to one theme.** The old `Headline Theme One & Headline Theme Two` template pushed a second theme into every title whether one deserved it or not — that produced `v5.0.0 – Your Real Training Zones & The Deferred Cleanups, Drained`, whose second half is repo-internal vocabulary from CLAUDE.md's deferred-breaking-changes list. Now: one theme by default, a second only when both are independently headline-worthy; no process terms a reader outside the repo can't parse; breaking changes belong in the upgrade section, not the title; ≤ 45 chars; no trailing comma clauses. Live title re-cut to `v5.0.0 – Your Real Training Zones`.
- Two anti-patterns added: don't skip the cut pass because the draft "reads well", and don't let a big release justify a long body.
- Steps renumbered 3-6; quality bar reworded to match the new structure.

## Test plan

Docs-only change to a skill file — no source, no tool behavior. `make can-release` is green (382 passed, ruff clean, pyright 0 errors). Validated by re-running the cut pass against the v5.0.0 notes: 830 → 351 words with every actionable item (tool names, renamed fields, removed parameters, contributor credits) retained; the dropped material — the `999` sentinel semantics, the four-sport 74-104% analysis, the Friel-tables aside — is all still in CHANGELOG.md, which the notes link to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

