### PR TITLE
Keep up to date - 9/5/26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for minimal final image
-FROM --platform=$TARGETPLATFORM ghcr.io/astral-sh/uv:latest AS uv
+FROM ghcr.io/astral-sh/uv:latest AS uv
 
-FROM --platform=$TARGETPLATFORM python:3.11-slim AS builder
+FROM python:3.11-slim AS builder
 
 # Install uv for faster dependency management
 COPY --from=uv /uv /usr/local/bin/uv
@@ -25,7 +25,7 @@ COPY src/ ./src/
 RUN uv sync --frozen --no-dev
 
 # Final stage - minimal runtime image
-FROM --platform=$TARGETPLATFORM python:3.11-slim
+FROM python:3.11-slim
 
 # Set working directory
 WORKDIR /app
@@ -36,6 +36,7 @@ COPY --from=builder /app/.venv /app/.venv
 # Copy application code
 COPY src/ ./src/
 COPY pyproject.toml ./
+COPY wrapper.py ./
 
 # Set environment variables
 ENV PATH="/app/.venv/bin:$PATH" \
@@ -47,4 +48,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import intervals_icu_mcp; print('ok')" || exit 1
 
 # Run the MCP server
-ENTRYPOINT ["python", "-m", "intervals_icu_mcp.server"]
+ENTRYPOINT ["python", "wrapper.py"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python wrapper.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <!-- mcp-name: io.github.hhopke/intervals-icu-mcp -->
+## Overview
+This is a clone of hhopke/intervals-icu-mcp but has additional files that allow it to be installed in docker and connected to Google Gemini Spark as a Connected App.
 
 # Intervals.icu MCP Server
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- mcp-name: io.github.hhopke/intervals-icu-mcp -->
-## Overview
+## Notes for this fork.
 This is a clone of hhopke/intervals-icu-mcp but has additional files that allow it to be installed in docker and connected to Google Gemini Spark as a Connected App.
 
 # Intervals.icu MCP Server

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+name: intervals-icu-mcp
+
+services:
+  intervals-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    command: ["python", "wrapper.py"]
+    environment:
+      - INTERVALS_ICU_API_KEY=${INTERVALS_ICU_API_KEY}
+      - INTERVALS_ICU_ATHLETE_ID=${INTERVALS_ICU_ATHLETE_ID}
+      - FASTMCP_ALLOWED_HOSTS=*

--- a/wrapper.py
+++ b/wrapper.py
@@ -49,8 +49,8 @@ class GoogleOAuthASGIMiddleware:
             path = scope.get("path", "")
             method = scope.get("method", "")
             
-            # We protect /mcp instead of /sse since we are using streamable-http
-            if path == "/mcp":
+            # We protect /sse for standard SSE transport
+            if path == "/sse":
                 if method != "OPTIONS":
                     headers = dict(scope.get("headers", []))
                     # Headers in ASGI are lowercase bytes
@@ -91,8 +91,8 @@ if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))
     
-    # Use streamable-http transport for Gemini Spark compatibility
-    app = mcp.http_app(transport="streamable-http")
+    # Use sse transport for Gemini Spark compatibility
+    app = mcp.http_app(transport="sse")
     
     # Add ProxyHeadersMiddleware to properly resolve request.base_url in Cloud Run
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")

--- a/wrapper.py
+++ b/wrapper.py
@@ -11,120 +11,63 @@ from starlette.middleware.cors import CORSMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from intervals_icu_mcp.server import mcp
 
-def get_base_url(request: Request) -> str:
-    # Use headers to construct the real base URL if behind a proxy
-    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
-    host = request.headers.get("host", request.url.hostname)
-    return f"{scheme}://{host}"
+import os
+import sys
+import httpx
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from urllib.parse import parse_qsl
 
-def get_oauth_discovery_document(request: Request):
-    base_url = get_base_url(request)
-    return JSONResponse({
-        "issuer": base_url,
-        "authorization_endpoint": f"{base_url}/auth",
-        "token_endpoint": f"{base_url}/token",
-        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
-        "response_types_supported": ["code", "token", "id_token", "none"],
-        "response_modes_supported": ["query", "fragment", "form_post"],
-        "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256"],
-        "scopes_supported": ["openid", "email", "profile"],
-        "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
-        "claims_supported": ["aud", "email", "email_verified", "exp", "family_name", "given_name", "iat", "iss", "name", "picture", "sub"],
-        "code_challenge_methods_supported": ["plain", "S256"],
-        "grant_types_supported": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
-    })
+# Ensure Python can resolve modules inside src/
+sys.path.insert(0, os.path.abspath("src"))
 
-from starlette.responses import RedirectResponse
-import urllib.parse
+from starlette.middleware.cors import CORSMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from intervals_icu_mcp.server import mcp
 
-@mcp.custom_route("/auth", methods=["GET"])
-async def auth_proxy(request: Request):
-    # Proxy authorization request to Google
-    qs = request.url.query
-    
-    # Force offline access so Google issues a refresh token, allowing Gemini to stay connected indefinitely
-    params = dict(urllib.parse.parse_qsl(qs))
-    params["access_type"] = "offline"
-    params["prompt"] = "consent"
-    
-    new_qs = urllib.parse.urlencode(params)
-    google_auth_url = f"https://accounts.google.com/o/oauth2/v2/auth?{new_qs}"
-    return RedirectResponse(url=google_auth_url)
-
-@mcp.custom_route("/token", methods=["POST"])
-async def token_proxy(request: Request):
-    # Proxy token exchange to Google
-    form_data = await request.form()
-    payload = dict(form_data)
-    
-    # Forward headers like Authorization (for basic auth)
-    headers = {}
-    if "authorization" in request.headers:
-        headers["authorization"] = request.headers["authorization"]
-        
-    print(f"Token proxy payload: {payload}", flush=True)
-    async with httpx.AsyncClient() as client:
-        resp = await client.post("https://oauth2.googleapis.com/token", data=payload, headers=headers)
-        print(f"Token proxy response ({resp.status_code}): {resp.text}", flush=True)
-        return JSONResponse(resp.json(), status_code=resp.status_code)
-
-# Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)
-@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
-async def oauth_authorization_server(request: Request):
-    return get_oauth_discovery_document(request)
-
-@mcp.custom_route("/.well-known/openid-configuration", methods=["GET"])
-async def openid_configuration(request: Request):
-    return get_oauth_discovery_document(request)
-
-# Strict ASGI Authentication Middleware for Google OAuth
-class GoogleOAuthASGIMiddleware:
+# Strict ASGI Authentication Middleware for Token Auth
+class TokenAuthASGIMiddleware:
     def __init__(self, app):
         self.app = app
-        # Optional: Set this environment variable in Cloud Run to bypass validation during testing
-        self.skip_validation = os.getenv("SKIP_AUTH_VALIDATION", "false").lower() == "true"
+        self.expected_token = os.getenv("MCP_SECRET")
+        if not self.expected_token:
+            print("WARNING: MCP_SECRET environment variable is not set! The server will reject all requests.", flush=True)
 
     async def __call__(self, scope, receive, send):
         if scope["type"] == "http":
             path = scope.get("path", "")
             method = scope.get("method", "")
             
-            # We protect /sse for standard SSE transport
             # Protect GET and POST on /mcp
             if path == "/mcp" and method in ("GET", "POST"):
                 headers = dict(scope.get("headers", []))
-                # Headers in ASGI are lowercase bytes
-                auth = headers.get(b"authorization", b"").decode("utf-8")
-                    
+                # Check for token in query parameters
+                query_string = scope.get("query_string", b"").decode("utf-8")
+                query_params = dict(parse_qsl(query_string))
+                provided_token = query_params.get("token")
+                
+                # Check for token in Authorization header
+                if not provided_token:
+                    auth = headers.get(b"authorization", b"").decode("utf-8")
+                    if auth.startswith("Bearer "):
+                        provided_token = auth.split(" ")[1]
+
                 async def reject():
                     await send({
                         "type": "http.response.start", 
                         "status": 401, 
                         "headers": [
-                            (b"content-type", b"application/json"),
-                            (b"www-authenticate", b"Bearer")
+                            (b"content-type", b"application/json")
                         ]
                     })
                     await send({
                         "type": "http.response.body", 
-                        "body": b'{"detail": "Unauthorized"}'
+                        "body": b'{"detail": "Unauthorized. Please provide ?token=... in the URL."}'
                     })
 
-                if not auth.startswith("Bearer "):
-                    # Require Bearer token
+                if not self.expected_token or provided_token != self.expected_token:
                     await reject()
                     return
-                    
-                token = auth.split(" ")[1]
-                
-                # Validate the token with Google
-                if not self.skip_validation:
-                    async with httpx.AsyncClient() as client:
-                        resp = await client.get(f"https://oauth2.googleapis.com/tokeninfo?access_token={token}")
-                        if resp.status_code != 200:
-                            await reject()
-                            return
 
         await self.app(scope, receive, send)
 
@@ -147,8 +90,8 @@ if __name__ == "__main__":
         allow_headers=["*"],
     )
     
-    # Wrap with our guaranteed Google Auth middleware at the very outer edge
-    protected_app = GoogleOAuthASGIMiddleware(app)
+    # Wrap with our simple Token Auth middleware at the very outer edge
+    protected_app = TokenAuthASGIMiddleware(app)
     
     import uvicorn
     uvicorn.run(protected_app, host=host, port=port)

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,0 +1,21 @@
+import os
+from starlette.middleware.cors import CORSMiddleware
+from intervals_icu_mcp.server import mcp
+
+# 1. Grab the underlying ASGI/Starlette app instance from FastMCP
+app = getattr(mcp, "_mcp_server", mcp).app if hasattr(mcp, "_mcp_server") else mcp.http_app
+
+# 2. Inject CORS middleware so OPTIONS requests return HTTP 200/204
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 3. Launch the server using FastMCP's built-in run method
+if __name__ == "__main__":
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    mcp.run(transport="sse", host=host, port=port)

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,11 +1,16 @@
 import os
+import sys
+
+# Ensure Python can resolve the package inside src/
+sys.path.insert(0, os.path.abspath("src"))
+
 from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
 
-# 1. Grab the underlying ASGI/Starlette app instance from FastMCP
+# Grab underlying ASGI app instance
 app = getattr(mcp, "_mcp_server", mcp).app if hasattr(mcp, "_mcp_server") else mcp.http_app
 
-# 2. Inject CORS middleware so OPTIONS requests return HTTP 200/204
+# Inject CORS middleware so OPTIONS preflight returns HTTP 200/204
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -14,7 +19,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# 3. Launch the server using FastMCP's built-in run method
 if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8000"))

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,12 +1,36 @@
 import os
 import sys
 import httpx
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 # Ensure Python can resolve modules inside src/
 sys.path.insert(0, os.path.abspath("src"))
 
 from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
+
+def get_oauth_discovery_document(request: Request):
+    # Construct the issuer URL from the incoming request (or fallback)
+    base_url = str(request.base_url).rstrip("/")
+    return JSONResponse({
+        "issuer": base_url,
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"]
+    })
+
+# Add OAuth Discovery endpoints for Gemini Spark
+@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
+async def oauth_authorization_server(request: Request):
+    return get_oauth_discovery_document(request)
+
+@mcp.custom_route("/.well-known/openid-configuration", methods=["GET"])
+async def openid_configuration(request: Request):
+    return get_oauth_discovery_document(request)
 
 # Strict ASGI Authentication Middleware for Google OAuth
 class GoogleOAuthASGIMiddleware:

--- a/wrapper.py
+++ b/wrapper.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath("src"))
 from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
 
-app = getattr(mcp, "_mcp_server", mcp).app if hasattr(mcp, "_mcp_server") else mcp.http_app
+app = mcp.http_app
 
 app.add_middleware(
     CORSMiddleware,

--- a/wrapper.py
+++ b/wrapper.py
@@ -50,8 +50,16 @@ async def token_proxy(request: Request):
     # Proxy token exchange to Google
     form_data = await request.form()
     payload = dict(form_data)
+    
+    # Forward headers like Authorization (for basic auth)
+    headers = {}
+    if "authorization" in request.headers:
+        headers["authorization"] = request.headers["authorization"]
+        
+    print(f"Token proxy payload: {payload}", flush=True)
     async with httpx.AsyncClient() as client:
-        resp = await client.post("https://oauth2.googleapis.com/token", data=payload)
+        resp = await client.post("https://oauth2.googleapis.com/token", data=payload, headers=headers)
+        print(f"Token proxy response ({resp.status_code}): {resp.text}", flush=True)
         return JSONResponse(resp.json(), status_code=resp.status_code)
 
 # Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)

--- a/wrapper.py
+++ b/wrapper.py
@@ -42,7 +42,14 @@ import urllib.parse
 async def auth_proxy(request: Request):
     # Proxy authorization request to Google
     qs = request.url.query
-    google_auth_url = f"https://accounts.google.com/o/oauth2/v2/auth?{qs}"
+    
+    # Force offline access so Google issues a refresh token, allowing Gemini to stay connected indefinitely
+    params = dict(urllib.parse.parse_qsl(qs))
+    params["access_type"] = "offline"
+    params["prompt"] = "consent"
+    
+    new_qs = urllib.parse.urlencode(params)
+    google_auth_url = f"https://accounts.google.com/o/oauth2/v2/auth?{new_qs}"
     return RedirectResponse(url=google_auth_url)
 
 @mcp.custom_route("/token", methods=["POST"])

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,67 +1,81 @@
 import os
 import sys
+import httpx
 
 # Ensure Python can resolve modules inside src/
 sys.path.insert(0, os.path.abspath("src"))
 
-from starlette.requests import Request
-from starlette.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.middleware import Middleware
-
 from intervals_icu_mcp.server import mcp
 
-# 1. Add Token Endpoint
-@mcp.custom_route("/token", methods=["POST"])
-async def token(request: Request):
-    form = await request.form()
-    client_id = form.get("client_id")
-    client_secret = form.get("client_secret")
-    
-    expected_id = os.getenv("SPARK_CLIENT_ID", "gemini-spark")
-    expected_secret = os.getenv("SPARK_CLIENT_SECRET", "secret123")
-    
-    if client_id == expected_id and client_secret == expected_secret:
-        return JSONResponse({
-            "access_token": "valid_spark_token_123",
-            "token_type": "Bearer",
-            "expires_in": 3600
-        })
-    else:
-        return JSONResponse({"error": "invalid_client"}, status_code=401)
+# Strict ASGI Authentication Middleware for Google OAuth
+class GoogleOAuthASGIMiddleware:
+    def __init__(self, app):
+        self.app = app
+        # Optional: Set this environment variable in Cloud Run to bypass validation during testing
+        self.skip_validation = os.getenv("SKIP_AUTH_VALIDATION", "false").lower() == "true"
 
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            path = scope.get("path", "")
+            method = scope.get("method", "")
+            
+            # Protect both /sse and /messages paths
+            if path in ["/sse", "/messages"]:
+                if method != "OPTIONS":
+                    headers = dict(scope.get("headers", []))
+                    # Headers in ASGI are lowercase bytes
+                    auth = headers.get(b"authorization", b"").decode("utf-8")
+                    
+                    async def reject(reason="invalid_token"):
+                        await send({
+                            "type": "http.response.start", 
+                            "status": 401, 
+                            "headers": [
+                                (b"content-type", b"application/json"),
+                                (b"www-authenticate", f'Bearer error="{reason}"'.encode("utf-8"))
+                            ]
+                        })
+                        await send({
+                            "type": "http.response.body", 
+                            "body": b'{"detail": "Unauthorized"}'
+                        })
 
-# 2. Strict Authentication Middleware
-class APIKeyAuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        # We only protect /sse and /messages paths
-        if request.url.path in ["/sse", "/messages"]:
-            # Cloud Run / Gemini also sends OPTIONS for preflight, don't block OPTIONS!
-            if request.method == "OPTIONS":
-                return await call_next(request)
-                
-            auth_header = request.headers.get("Authorization", "")
-            if auth_header != "Bearer valid_spark_token_123":
-                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
-        return await call_next(request)
+                    if not auth.startswith("Bearer "):
+                        # Require Bearer token
+                        await reject("invalid_request")
+                        return
+                    
+                    token = auth.split(" ")[1]
+                    
+                    # Validate the token with Google
+                    if not self.skip_validation:
+                        async with httpx.AsyncClient() as client:
+                            resp = await client.get(f"https://oauth2.googleapis.com/tokeninfo?access_token={token}")
+                            if resp.status_code != 200:
+                                await reject("invalid_token")
+                                return
+
+        await self.app(scope, receive, send)
 
 if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))
     
-    mcp.run(
-        transport="sse", 
-        host=host, 
-        port=port,
-        middleware=[
-            Middleware(APIKeyAuthMiddleware),
-            Middleware(
-                CORSMiddleware,
-                allow_origins=["*"],
-                allow_credentials=True,
-                allow_methods=["*"],
-                allow_headers=["*"],
-            )
-        ]
+    # Extract the raw Starlette ASGI app from FastMCP
+    app = mcp.http_app()
+    
+    # Add CORS (This handles OPTIONS requests before Auth can block them)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
+    
+    # Wrap with our guaranteed Google Auth middleware at the very outer edge
+    protected_app = GoogleOAuthASGIMiddleware(app)
+    
+    import uvicorn
+    uvicorn.run(protected_app, host=host, port=port)

--- a/wrapper.py
+++ b/wrapper.py
@@ -4,10 +4,64 @@ import sys
 # Ensure Python can resolve modules inside src/
 sys.path.insert(0, os.path.abspath("src"))
 
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware import Middleware
+
 from intervals_icu_mcp.server import mcp
 
-# In fastmcp v3, mcp.run with transport="sse" automatically handles CORS and starts the server.
+# 1. Add Token Endpoint
+@mcp.custom_route("/token", methods=["POST"])
+async def token(request: Request):
+    form = await request.form()
+    client_id = form.get("client_id")
+    client_secret = form.get("client_secret")
+    
+    expected_id = os.getenv("SPARK_CLIENT_ID", "gemini-spark")
+    expected_secret = os.getenv("SPARK_CLIENT_SECRET", "secret123")
+    
+    if client_id == expected_id and client_secret == expected_secret:
+        return JSONResponse({
+            "access_token": "valid_spark_token_123",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        })
+    else:
+        return JSONResponse({"error": "invalid_client"}, status_code=401)
+
+
+# 2. Strict Authentication Middleware
+class APIKeyAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        # We only protect /sse and /messages paths
+        if request.url.path in ["/sse", "/messages"]:
+            # Cloud Run / Gemini also sends OPTIONS for preflight, don't block OPTIONS!
+            if request.method == "OPTIONS":
+                return await call_next(request)
+                
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header != "Bearer valid_spark_token_123":
+                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        return await call_next(request)
+
 if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))
-    mcp.run(transport="sse", host=host, port=port)
+    
+    mcp.run(
+        transport="sse", 
+        host=host, 
+        port=port,
+        middleware=[
+            Middleware(APIKeyAuthMiddleware),
+            Middleware(
+                CORSMiddleware,
+                allow_origins=["*"],
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+        ]
+    )

--- a/wrapper.py
+++ b/wrapper.py
@@ -10,27 +10,22 @@ sys.path.insert(0, os.path.abspath("src"))
 from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
 
-def get_oauth_discovery_document(request: Request):
-    # Construct the issuer URL from the incoming request (or fallback)
-    base_url = str(request.base_url).rstrip("/")
+def get_oauth_protected_resource():
     return JSONResponse({
-        "issuer": base_url,
-        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-        "token_endpoint": "https://oauth2.googleapis.com/token",
-        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
-        "response_types_supported": ["code"],
-        "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256"]
+        "authorization_servers": [
+            "https://accounts.google.com"
+        ]
     })
 
-# Add OAuth Discovery endpoints for Gemini Spark
-@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
-async def oauth_authorization_server(request: Request):
-    return get_oauth_discovery_document(request)
+# Add RFC 9289 OAuth Protected Resource Metadata
+@mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
+async def oauth_protected_resource_root(request: Request):
+    return get_oauth_protected_resource()
 
-@mcp.custom_route("/.well-known/openid-configuration", methods=["GET"])
-async def openid_configuration(request: Request):
-    return get_oauth_discovery_document(request)
+@mcp.custom_route("/.well-known/oauth-protected-resource/mcp", methods=["GET"])
+async def oauth_protected_resource_mcp(request: Request):
+    return get_oauth_protected_resource()
+
 
 # Strict ASGI Authentication Middleware for Google OAuth
 class GoogleOAuthASGIMiddleware:
@@ -44,8 +39,8 @@ class GoogleOAuthASGIMiddleware:
             path = scope.get("path", "")
             method = scope.get("method", "")
             
-            # Protect both /sse and /messages paths
-            if path in ["/sse", "/messages"]:
+            # We now protect /mcp instead of /sse since we are using streamable-http
+            if path == "/mcp":
                 if method != "OPTIONS":
                     headers = dict(scope.get("headers", []))
                     # Headers in ASGI are lowercase bytes
@@ -86,8 +81,8 @@ if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))
     
-    # Extract the raw Starlette ASGI app from FastMCP
-    app = mcp.http_app()
+    # Use streamable-http transport for Gemini Spark compatibility
+    app = mcp.http_app(transport="streamable-http")
     
     # Add CORS (This handles OPTIONS requests before Auth can block them)
     app.add_middleware(

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,16 +1,14 @@
 import os
 import sys
 
-# Ensure Python can resolve the package inside src/
+# Ensure Python can resolve modules inside src/
 sys.path.insert(0, os.path.abspath("src"))
 
 from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
 
-# Grab underlying ASGI app instance
 app = getattr(mcp, "_mcp_server", mcp).app if hasattr(mcp, "_mcp_server") else mcp.http_app
 
-# Inject CORS middleware so OPTIONS preflight returns HTTP 200/204
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -21,5 +19,5 @@ app.add_middleware(
 
 if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
-    port = int(os.getenv("PORT", "8000"))
+    port = int(os.getenv("PORT", "8080"))
     mcp.run(transport="sse", host=host, port=port)

--- a/wrapper.py
+++ b/wrapper.py
@@ -8,24 +8,53 @@ from starlette.responses import JSONResponse
 sys.path.insert(0, os.path.abspath("src"))
 
 from starlette.middleware.cors import CORSMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from intervals_icu_mcp.server import mcp
 
-def get_oauth_protected_resource():
+def get_base_url(request: Request) -> str:
+    # Use headers to construct the real base URL if behind a proxy
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("host", request.url.hostname)
+    return f"{scheme}://{host}"
+
+def get_oauth_discovery_document(request: Request):
+    base_url = get_base_url(request)
     return JSONResponse({
+        "issuer": base_url,
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"]
+    })
+
+def get_oauth_protected_resource(request: Request):
+    base_url = get_base_url(request)
+    return JSONResponse({
+        "resource": base_url,
         "authorization_servers": [
             "https://accounts.google.com"
         ]
     })
 
+# Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)
+@mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
+async def oauth_authorization_server(request: Request):
+    return get_oauth_discovery_document(request)
+
+@mcp.custom_route("/.well-known/openid-configuration", methods=["GET"])
+async def openid_configuration(request: Request):
+    return get_oauth_discovery_document(request)
+
 # Add RFC 9289 OAuth Protected Resource Metadata
 @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
 async def oauth_protected_resource_root(request: Request):
-    return get_oauth_protected_resource()
+    return get_oauth_protected_resource(request)
 
 @mcp.custom_route("/.well-known/oauth-protected-resource/mcp", methods=["GET"])
 async def oauth_protected_resource_mcp(request: Request):
-    return get_oauth_protected_resource()
-
+    return get_oauth_protected_resource(request)
 
 # Strict ASGI Authentication Middleware for Google OAuth
 class GoogleOAuthASGIMiddleware:
@@ -39,20 +68,20 @@ class GoogleOAuthASGIMiddleware:
             path = scope.get("path", "")
             method = scope.get("method", "")
             
-            # We now protect /mcp instead of /sse since we are using streamable-http
+            # We protect /mcp instead of /sse since we are using streamable-http
             if path == "/mcp":
                 if method != "OPTIONS":
                     headers = dict(scope.get("headers", []))
                     # Headers in ASGI are lowercase bytes
                     auth = headers.get(b"authorization", b"").decode("utf-8")
                     
-                    async def reject(reason="invalid_token"):
+                    async def reject():
                         await send({
                             "type": "http.response.start", 
                             "status": 401, 
                             "headers": [
                                 (b"content-type", b"application/json"),
-                                (b"www-authenticate", f'Bearer error="{reason}"'.encode("utf-8"))
+                                (b"www-authenticate", b"Bearer")
                             ]
                         })
                         await send({
@@ -62,7 +91,7 @@ class GoogleOAuthASGIMiddleware:
 
                     if not auth.startswith("Bearer "):
                         # Require Bearer token
-                        await reject("invalid_request")
+                        await reject()
                         return
                     
                     token = auth.split(" ")[1]
@@ -72,7 +101,7 @@ class GoogleOAuthASGIMiddleware:
                         async with httpx.AsyncClient() as client:
                             resp = await client.get(f"https://oauth2.googleapis.com/tokeninfo?access_token={token}")
                             if resp.status_code != 200:
-                                await reject("invalid_token")
+                                await reject()
                                 return
 
         await self.app(scope, receive, send)
@@ -83,6 +112,9 @@ if __name__ == "__main__":
     
     # Use streamable-http transport for Gemini Spark compatibility
     app = mcp.http_app(transport="streamable-http")
+    
+    # Add ProxyHeadersMiddleware to properly resolve request.base_url in Cloud Run
+    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
     
     # Add CORS (This handles OPTIONS requests before Auth can block them)
     app.add_middleware(

--- a/wrapper.py
+++ b/wrapper.py
@@ -28,16 +28,6 @@ def get_oauth_discovery_document(request: Request):
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"]
     })
-
-def get_oauth_protected_resource(request: Request):
-    base_url = get_base_url(request)
-    return JSONResponse({
-        "resource": base_url,
-        "authorization_servers": [
-            "https://accounts.google.com"
-        ]
-    })
-
 # Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)
 @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
 async def oauth_authorization_server(request: Request):
@@ -46,15 +36,6 @@ async def oauth_authorization_server(request: Request):
 @mcp.custom_route("/.well-known/openid-configuration", methods=["GET"])
 async def openid_configuration(request: Request):
     return get_oauth_discovery_document(request)
-
-# Add RFC 9289 OAuth Protected Resource Metadata
-@mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
-async def oauth_protected_resource_root(request: Request):
-    return get_oauth_protected_resource(request)
-
-@mcp.custom_route("/.well-known/oauth-protected-resource/mcp", methods=["GET"])
-async def oauth_protected_resource_mcp(request: Request):
-    return get_oauth_protected_resource(request)
 
 # Strict ASGI Authentication Middleware for Google OAuth
 class GoogleOAuthASGIMiddleware:

--- a/wrapper.py
+++ b/wrapper.py
@@ -26,7 +26,9 @@ def get_oauth_discovery_document(request: Request):
         "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
         "response_types_supported": ["code"],
         "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256"]
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": ["openid", "email", "profile"],
+        "grant_types_supported": ["authorization_code", "refresh_token"]
     })
 # Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)
 @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
@@ -50,40 +52,40 @@ class GoogleOAuthASGIMiddleware:
             method = scope.get("method", "")
             
             # We protect /sse for standard SSE transport
-            if path == "/sse":
-                if method != "OPTIONS":
-                    headers = dict(scope.get("headers", []))
-                    # Headers in ASGI are lowercase bytes
-                    auth = headers.get(b"authorization", b"").decode("utf-8")
+            # Protect GET /sse and POST /messages
+            if (path == "/sse" and method == "GET") or (path.startswith("/messages") and method == "POST"):
+                headers = dict(scope.get("headers", []))
+                # Headers in ASGI are lowercase bytes
+                auth = headers.get(b"authorization", b"").decode("utf-8")
                     
-                    async def reject():
-                        await send({
-                            "type": "http.response.start", 
-                            "status": 401, 
-                            "headers": [
-                                (b"content-type", b"application/json"),
-                                (b"www-authenticate", b"Bearer")
-                            ]
-                        })
-                        await send({
-                            "type": "http.response.body", 
-                            "body": b'{"detail": "Unauthorized"}'
-                        })
+                async def reject():
+                    await send({
+                        "type": "http.response.start", 
+                        "status": 401, 
+                        "headers": [
+                            (b"content-type", b"application/json"),
+                            (b"www-authenticate", b"Bearer")
+                        ]
+                    })
+                    await send({
+                        "type": "http.response.body", 
+                        "body": b'{"detail": "Unauthorized"}'
+                    })
 
-                    if not auth.startswith("Bearer "):
-                        # Require Bearer token
-                        await reject()
-                        return
+                if not auth.startswith("Bearer "):
+                    # Require Bearer token
+                    await reject()
+                    return
                     
-                    token = auth.split(" ")[1]
-                    
-                    # Validate the token with Google
-                    if not self.skip_validation:
-                        async with httpx.AsyncClient() as client:
-                            resp = await client.get(f"https://oauth2.googleapis.com/tokeninfo?access_token={token}")
-                            if resp.status_code != 200:
-                                await reject()
-                                return
+                token = auth.split(" ")[1]
+                
+                # Validate the token with Google
+                if not self.skip_validation:
+                    async with httpx.AsyncClient() as client:
+                        resp = await client.get(f"https://oauth2.googleapis.com/tokeninfo?access_token={token}")
+                        if resp.status_code != 200:
+                            await reject()
+                            return
 
         await self.app(scope, receive, send)
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -21,15 +21,39 @@ def get_oauth_discovery_document(request: Request):
     base_url = get_base_url(request)
     return JSONResponse({
         "issuer": base_url,
-        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "authorization_endpoint": f"{base_url}/auth",
+        "token_endpoint": f"{base_url}/token",
         "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
-        "response_types_supported": ["code"],
+        "response_types_supported": ["code", "token", "id_token", "none"],
+        "response_modes_supported": ["query", "fragment", "form_post"],
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],
         "scopes_supported": ["openid", "email", "profile"],
-        "grant_types_supported": ["authorization_code", "refresh_token"]
+        "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+        "claims_supported": ["aud", "email", "email_verified", "exp", "family_name", "given_name", "iat", "iss", "name", "picture", "sub"],
+        "code_challenge_methods_supported": ["plain", "S256"],
+        "grant_types_supported": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
     })
+
+from starlette.responses import RedirectResponse
+import urllib.parse
+
+@mcp.custom_route("/auth", methods=["GET"])
+async def auth_proxy(request: Request):
+    # Proxy authorization request to Google
+    qs = request.url.query
+    google_auth_url = f"https://accounts.google.com/o/oauth2/v2/auth?{qs}"
+    return RedirectResponse(url=google_auth_url)
+
+@mcp.custom_route("/token", methods=["POST"])
+async def token_proxy(request: Request):
+    # Proxy token exchange to Google
+    form_data = await request.form()
+    payload = dict(form_data)
+    async with httpx.AsyncClient() as client:
+        resp = await client.post("https://oauth2.googleapis.com/token", data=payload)
+        return JSONResponse(resp.json(), status_code=resp.status_code)
+
 # Add OAuth Discovery endpoints for Gemini Spark (RFC 8414 & OpenID)
 @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
 async def oauth_authorization_server(request: Request):
@@ -52,8 +76,8 @@ class GoogleOAuthASGIMiddleware:
             method = scope.get("method", "")
             
             # We protect /sse for standard SSE transport
-            # Protect GET /sse and POST /messages
-            if (path == "/sse" and method == "GET") or (path.startswith("/messages") and method == "POST"):
+            # Protect GET and POST on /mcp
+            if path == "/mcp" and method in ("GET", "POST"):
                 headers = dict(scope.get("headers", []))
                 # Headers in ASGI are lowercase bytes
                 auth = headers.get(b"authorization", b"").decode("utf-8")
@@ -93,8 +117,8 @@ if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))
     
-    # Use sse transport for Gemini Spark compatibility
-    app = mcp.http_app(transport="sse")
+    # Use streamable-http transport for Gemini Spark compatibility
+    app = mcp.http_app(transport="streamable-http")
     
     # Add ProxyHeadersMiddleware to properly resolve request.base_url in Cloud Run
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")

--- a/wrapper.py
+++ b/wrapper.py
@@ -4,19 +4,9 @@ import sys
 # Ensure Python can resolve modules inside src/
 sys.path.insert(0, os.path.abspath("src"))
 
-from starlette.middleware.cors import CORSMiddleware
 from intervals_icu_mcp.server import mcp
 
-app = mcp.http_app
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
+# In fastmcp v3, mcp.run with transport="sse" automatically handles CORS and starts the server.
 if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8080"))


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? If it closes an issue, write "Closes #123". -->

## Changes

<!-- A short bulleted list of the concrete changes. -->

-
-

## Checklist

- [ ] `make can-release` passes locally (tests, ruff, pyright)
- [ ] New tools have a corresponding respx-mocked test file in `tests/`
- [ ] Public-facing behavior changes are reflected in the README or `docs/`
- [ ] New MCP tools follow the `icu_` prefix convention and include `destructiveHint` where appropriate
- [ ] No API keys, athlete IDs, or other credentials are committed

> [!NOTE]
> No need to touch `CHANGELOG.md` — the maintainer adds entries at merge time.

## Test plan

<!-- How did you verify the change? e.g. unit tests added, tested live against a Claude Desktop session, etc. -->
